### PR TITLE
Change download buttons for a table with all components

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,5 +12,19 @@ url: "https://wpewebkit.org"
 twitter_username: WPEWebKit
 exclude: ['README.md', 'generate-site', 'releases', 'webkit-release', 'generate-security-advisory', 'reference', 'cvedata']
 
+packages:
+  - slug: wpewebkit
+    name: "WPE WebKit"
+  - slug: libwpe
+    name: "libwpe"
+  - slug: wpebackend-fdo
+    name: "WPEBackend-fdo"
+
+release_kinds:
+  - tag: stable
+    color: primary
+  - tag: unstable
+    color: secondary
+
 # Build settings
 markdown: kramdown

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,5 +1,5 @@
 <!-- Contact -->
-<section class="content-section bg-dark text-white text-center" id="contact">
+<section class="content-section bg-dark text-white text-center pb-5 pt-6" id="contact">
   <div class="container text-center">
     <div class="row">
       <div class="col-lg-10 mx-auto">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -9,18 +9,18 @@
 
   <title>{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}</title>
   <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
-  <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
-  <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}">
+  <link rel="canonical" href="{{ page.url | replace:'index.html','' | absolute_url }}">
+  <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ '/feed.xml' | absolute_url }}">
 
   <!-- Bootstrap Core CSS -->
-  <link rel="stylesheet" href="{{ "/vendor/bootstrap/css/bootstrap.min.css" | prepend: site.baseurl }}">
+  <link rel="stylesheet" href="{{ '/vendor/bootstrap/css/bootstrap.min.css' | absolute_url }}">
 
   <!-- Custom Fonts -->
-  <link rel="stylesheet" href="{{ "/vendor/font-awesome/css/font-awesome.min.css" | prepend: site.baseurl }}">
-  <link rel="stylesheet" href="{{ "/vendor/simple-line-icons/css/simple-line-icons.css" | prepend: site.baseurl }}">
+  <link rel="stylesheet" href="{{ '/vendor/font-awesome/css/font-awesome.min.css' | absolute_url }}">
+  <link rel="stylesheet" href="{{ '/vendor/simple-line-icons/css/simple-line-icons.css' | absolute_url }}">
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700,300italic,400italic,700italic" rel="stylesheet" type="text/css">
 
   <!-- Custom CSS -->
-  <link rel="stylesheet" href="{{ "/css/stylish-portfolio.min.css" | prepend: site.baseurl }}">
+  <link rel="stylesheet" href="{{ '/css/stylish-portfolio.min.css' | absolute_url }}">
 
 </head>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,7 +1,7 @@
 <!-- Header -->
 <header class="masthead d-flex small-header">
   <div class="container text-center my-auto">
-    <h1 class="mb-1"><a href="{{ "/" | prepend: site.baseurl }}">{{ site.title }}</a></h1>
+    <h1 class="mb-1"><a href="{{ '/' | absolute_url }}">{{ site.title }}</a></h1>
     <h3 class="mb-5">
       <em>{{ site.subtitle }}</em>
     </h3>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -19,7 +19,7 @@ layout: page
 
         {{ content }}
 
-        <p class="text-right"><a class="btn btn-primary" href="{{ "/" | prepend: site.baseurl }}"><i class="icon-home mr-1"></i> Home</a></p>
+        <p class="text-right"><a class="btn btn-primary" href="{{ '/' | absolute_url }}"><i class="icon-home mr-1"></i> Home</a></p>
       </div>
     </div>
   </div>

--- a/_posts/2018-05-09-wpe-2.21.1-released.md
+++ b/_posts/2018-05-09-wpe-2.21.1-released.md
@@ -3,8 +3,7 @@ layout: post
 title: "WPE WebKit 2.21.1 released!"
 version: 2.21.1
 date: 2018-05-09
-tags: release
-category: unstable
+tags: [release, unstable]
 permalink: /release/wpe-2-21-1.html
 download: https://wpewebkit.org/releases/wpewebkit-2.21.1.tar.xz
 ---

--- a/_posts/2018-05-14-wpe-2.19.93-released.md
+++ b/_posts/2018-05-14-wpe-2.19.93-released.md
@@ -3,8 +3,7 @@ layout: post
 title: "WPE WebKit 2.19.93 released!"
 version: 2.19.93
 date: 2018-05-08
-tags: release
-category: unstable
+tags: [release, unstable]
 permalink: /release/wpe-2.19-93.html
 download: https://wpewebkit.org/releases/wpewebkit-2.19.93.tar.xz
 ---

--- a/_posts/2018-05-18-wpe-2.10.0-released.md
+++ b/_posts/2018-05-18-wpe-2.10.0-released.md
@@ -3,8 +3,7 @@ layout: post
 title: "WPE WebKit 2.20.0 released!"
 version: 2.20.0
 date: 2018-05-18
-tags: release
-category: stable
+tags: [release, stable]
 permalink: /release/wpe-2.20.0.html
 download: https://wpewebkit.org/releases/wpewebkit-2.20.0.tar.xz
 ---

--- a/_posts/2018-05-25-wpe-2.21.2-released.md
+++ b/_posts/2018-05-25-wpe-2.21.2-released.md
@@ -3,8 +3,7 @@ layout: post
 title: "WPE WebKit 2.21.2 released!"
 version: 2.21.2
 date: 2018-05-25
-tags: release
-category: unstable
+tags: [release, unstable]
 permalink: /release/wpe-2.21.2.html
 download: https://wpewebkit.org/releases/wpewebkit-2.21.2.tar.xz
 ---

--- a/_posts/2018-06-14-wpe-2.20.1-releeased.md
+++ b/_posts/2018-06-14-wpe-2.20.1-releeased.md
@@ -3,8 +3,7 @@ layout: post
 title: "WPE WebKit 2.20.1 released!"
 version: 2.20.1
 date: 2018-06-14
-tags: release
-category: stable
+tags: [release, stable]
 permalink: /release/wpe-2.20.1.html
 download: https://wpewebkit.org/releases/wpewebkit-2.20.1.tar.xz
 ---

--- a/_posts/2018-07-09-wpebackend-0.2.0-released.md
+++ b/_posts/2018-07-09-wpebackend-0.2.0-released.md
@@ -2,7 +2,8 @@
 layout: post
 title: "WPEBackend 0.2.0 released!"
 date: 2018-07-09
-tags: release
+tags: [release, stable]
+version: 0.2.0
 permalink: /release/wpebackend-0.2.0.html
 download: https://wpewebkit.org/releases/wpebackend-0.2.0.tar.xz
 ---

--- a/_posts/2018-08-06-wpe-2.20.2-released.md
+++ b/_posts/2018-08-06-wpe-2.20.2-released.md
@@ -3,8 +3,7 @@ layout: post
 title: "WPE WebKit 2.20.2 released!"
 version: 2.20.2
 date: 2018-08-06
-tags: release
-category: stable
+tags: [release, stable]
 permalink: /release/wpe-2.20.2.html
 download: https://wpewebkit.org/releases/wpewebkit-2.20.2.tar.xz
 ---

--- a/_posts/2018-08-21-libwpe-1.0.0-released.md
+++ b/_posts/2018-08-21-libwpe-1.0.0-released.md
@@ -2,7 +2,8 @@
 layout: post
 title: "libwpe 1.0.0 released!"
 date: 2018-08-21
-tags: release
+tags: [release, stable]
+version: 1.0.0
 permalink: /release/libwpe-1.0.0.html
 download: https://wpewebkit.org/releases/libwpe-1.0.0.tar.xz
 ---

--- a/_posts/2018-08-21-wpe-2.21.91-released.md
+++ b/_posts/2018-08-21-wpe-2.21.91-released.md
@@ -3,8 +3,7 @@ layout: post
 title: "WPE WebKit 2.21.91 released!"
 version: 2.21.91
 date: 2018-08-21 12:00
-tags: release
-category: unstable
+tags: [release, unstable]
 permalink: /release/wpe-2.21.91.html
 download: https://wpewebkit.org/releases/wpewebkit-2.21.91.tar.xz
 ---

--- a/_posts/2018-08-21-wpebackend-fdo-1.0.0-released.md
+++ b/_posts/2018-08-21-wpebackend-fdo-1.0.0-released.md
@@ -2,7 +2,8 @@
 layout: post
 title: "WPEBackend-fdo 1.0.0 released!"
 date: 2018-08-21
-tags: release
+tags: [release, stable]
+version: 1.0.0
 permalink: /release/wpebackend-fdo-1.0.0.html
 download: https://wpewebkit.org/releases/wpebackend-fdo-1.0.0.tar.xz
 ---

--- a/_posts/2018-09-07-wpe-2.21.92-released.md
+++ b/_posts/2018-09-07-wpe-2.21.92-released.md
@@ -3,8 +3,7 @@ layout: post
 title: "WPE WebKit 2.21.92 released!"
 version: 2.21.92
 date: 2018-09-07 03:08
-tags: release
-category: unstable
+tags: [release, unstable]
 permalink: /release/wpe-2.21.92.html
 download: https://wpewebkit.org/releases/wpewebkit-2.21.92.tar.xz
 ---

--- a/_posts/2018-10-02-wpe-2.22.0-released.md
+++ b/_posts/2018-10-02-wpe-2.22.0-released.md
@@ -3,8 +3,7 @@ layout: post
 title: "WPE WebKit 2.22.0 released!"
 version: 2.22.0
 date: 2018-10-02 16:20
-tags: release
-category: stable
+tags: [release, stable]
 permalink: /release/wpe-2.22.0.html
 download: https://wpewebkit.org/releases/wpewebkit-2.22.0.tar.xz
 ---

--- a/_posts/2018-11-06-wpewebkit-2.22.1-released.md
+++ b/_posts/2018-11-06-wpewebkit-2.22.1-released.md
@@ -3,8 +3,7 @@ layout: post
 title: "WPE WebKit 2.22.1 released!"
 version: 2.22.1
 date: 2018-11-06 17:00
-tags: release
-category: stable
+tags: [release, stable]
 permalink: /release/wpe-2.22.1.html
 download: https://wpewebkit.org/releases/wpewebkit-2.22.1.tar.xz
 ---

--- a/_posts/2018-11-21-wpewebkit-2.22.2-released.md
+++ b/_posts/2018-11-21-wpewebkit-2.22.2-released.md
@@ -3,8 +3,7 @@ layout: post
 title: "WPE WebKit 2.22.2 released!"
 version: 2.22.2
 date: 2018-11-21 19:00
-tags: release
-category: stable
+tags: [release, stable]
 permalink: /release/wpe-2.22.2.html
 download: https://wpewebkit.org/releases/wpewebkit-2.22.2.tar.xz
 ---

--- a/_posts/2018-12-13-libwpe-1.1.0-released.md
+++ b/_posts/2018-12-13-libwpe-1.1.0-released.md
@@ -2,7 +2,8 @@
 layout: post
 title: "libwpe 1.1.0 released!"
 date: 2018-12-13
-tags: release
+tags: [release, unstable]
+version: 1.1.0
 permalink: /release/libwpe-1.1.0.html
 download: https://wpewebkit.org/releases/libwpe-1.1.0.tar.xz
 ---

--- a/_posts/2018-12-13-wpewebkit-2.22.3-released.md
+++ b/_posts/2018-12-13-wpewebkit-2.22.3-released.md
@@ -2,8 +2,7 @@
 layout: post
 title: "WPE WebKit 2.22.3 released!"
 version: 2.22.3
-tags: release
-category: stable
+tags: [release, stable]
 permalink: /release/wpe-2.22.3.html
 download: https://wpewebkit.org/releases/wpewebkit-2.22.3.tar.xz
 ---

--- a/_posts/2018-12-14-wpebackend-fdo-1.1.0-released.md
+++ b/_posts/2018-12-14-wpebackend-fdo-1.1.0-released.md
@@ -2,7 +2,8 @@
 layout: post
 title: "WPEBackend-fdo 1.1.0 released!"
 date: 2018-12-14
-tags: release
+tags: [release, unstable]
+version: 1.1.0
 permalink: /release/wpebackend-fdo-1.1.0.html
 download: https://wpewebkit.org/releases/wpebackend-fdo-1.1.0.tar.xz
 ---

--- a/_posts/2019-01-06-wpebackend-fdo-1.0.1-released.md
+++ b/_posts/2019-01-06-wpebackend-fdo-1.0.1-released.md
@@ -2,7 +2,8 @@
 layout: post
 title: "WPEBackend-fdo 1.0.1 released!"
 date: 2019-01-06
-tags: release
+tags: [release, stable]
+version: 1.0.1
 permalink: /release/wpebackend-fdo-1.0.1.html
 download: https://wpewebkit.org/releases/wpebackend-fdo-1.0.1.tar.xz
 ---

--- a/_posts/2019-02-09-wpewebkit-2.22.4-released.md
+++ b/_posts/2019-02-09-wpewebkit-2.22.4-released.md
@@ -2,8 +2,7 @@
 layout: post
 title: "WPE WebKit 2.22.4 released!"
 version: 2.22.4
-tags: release
-category: stable
+tags: [release, stable]
 permalink: /release/wpe-2.22.4.html
 download: https://wpewebkit.org/releases/wpewebkit-2.22.4.tar.xz
 ---

--- a/_posts/2019-02-21-wpewebkit-2.23.90-released.md
+++ b/_posts/2019-02-21-wpewebkit-2.23.90-released.md
@@ -2,8 +2,7 @@
 layout: post
 title: WPE WebKit 2.23.90 released!
 version: 2.23.90
-tags: release
-category: unstable
+tags: [release, unstable]
 permalink: /release/wpewebkit-2.23.90.html
 download: https://wpewebkit.org/releases/wpewebkit-2.23.90.tar.xz
 ---

--- a/_posts/2019-02-26-wpebackend-fdo-1.1.90.md
+++ b/_posts/2019-02-26-wpebackend-fdo-1.1.90.md
@@ -2,7 +2,8 @@
 layout: post
 title: "WPEBackend-fdo 1.1.90 released!"
 date: 2019-02-26
-tags: release
+tags: [release, unstable]
+version: 1.1.90
 permalink: /release/wpebackend-fdo-1.1.90.html
 download: https://wpewebkit.org/releases/wpebackend-fdo-1.1.90.tar.xz
 ---

--- a/_posts/2019-03-01-wpewebkit-2.22.5-released.md
+++ b/_posts/2019-03-01-wpewebkit-2.22.5-released.md
@@ -2,8 +2,7 @@
 layout: post
 title: "WPE WebKit 2.22.5 released!"
 version: 2.22.5
-tags: release
-category: stable
+tags: [release, stable]
 permalink: /release/wpe-2.22.5.html
 download: https://wpewebkit.org/releases/wpewebkit-2.22.5.tar.xz
 ---

--- a/_posts/2019-03-04-libwpe-1.1.90-released.md
+++ b/_posts/2019-03-04-libwpe-1.1.90-released.md
@@ -2,7 +2,8 @@
 layout: post
 title: "libwpe 1.1.90 released!"
 date: 2019-03-04
-tags: release
+tags: [release, unstable]
+version: 1.1.90
 permalink: /release/libwpe-1.1.90.html
 download: https://wpewebkit.org/releases/libwpe-1.1.90.tar.xz
 ---

--- a/_posts/2019-03-14-wpebackend-fdo-1.1.91.md
+++ b/_posts/2019-03-14-wpebackend-fdo-1.1.91.md
@@ -2,7 +2,8 @@
 layout: post
 title: "WPEBackend-fdo 1.1.91 released!"
 date: 2019-03-14
-tags: release
+tags: [release, unstable]
+version: 1.1.91
 permalink: /release/wpebackend-fdo-1.1.91.html
 download: https://wpewebkit.org/releases/wpebackend-fdo-1.1.91.tar.xz
 ---

--- a/_posts/2019-03-18-wpewebkit-2.23.91.md
+++ b/_posts/2019-03-18-wpewebkit-2.23.91.md
@@ -2,8 +2,7 @@
 layout: post
 title: WPE WebKit 2.23.91 released!
 version: 2.23.91
-tags: release
-category: unstable
+tags: [release, unstable]
 permalink: /release/wpewebkit-2.23.91.html
 download: https://wpewebkit.org/releases/wpewebkit-2.23.91.tar.xz
 ---

--- a/_posts/2019-03-26-libwpe-1.2.0-released.md
+++ b/_posts/2019-03-26-libwpe-1.2.0-released.md
@@ -2,7 +2,8 @@
 layout: post
 title: "libwpe 1.2.0 released!"
 date: 2019-03-26
-tags: release
+tags: [release, stable]
+version: 1.2.0
 permalink: /release/libwpe-1.2.0.html
 download: https://wpewebkit.org/releases/libwpe-1.2.0.tar.xz
 ---

--- a/_posts/2019-03-26-wpebackend-fdo-1.2.0.md
+++ b/_posts/2019-03-26-wpebackend-fdo-1.2.0.md
@@ -2,7 +2,8 @@
 layout: post
 title: "WPEBackend-fdo 1.2.0 released!"
 date: 2019-03-26
-tags: release
+tags: [release, stable]
+version: 1.2.0
 permalink: /release/wpebackend-fdo-1.2.0.html
 download: https://wpewebkit.org/releases/wpebackend-fdo-1.2.0.tar.xz
 ---

--- a/_posts/2019-03-27-wpewebkit-2.24.0.md
+++ b/_posts/2019-03-27-wpewebkit-2.24.0.md
@@ -2,8 +2,7 @@
 layout: post
 title: WPE WebKit 2.24.0 released!
 version: 2.24.0
-tags: release
-category: stable
+tags: [release, stable]
 permalink: /release/wpewebkit-2.24.0.html
 download: https://wpewebkit.org/releases/wpewebkit-2.24.0.tar.xz
 ---

--- a/_posts/2019-04-19-wpewebkit-2.24.1.md
+++ b/_posts/2019-04-19-wpewebkit-2.24.1.md
@@ -2,8 +2,7 @@
 layout: post
 title: WPE WebKit 2.24.1 released!
 version: 2.24.1
-tags: release
-category: stable
+tags: [release, stable]
 permalink: /release/wpewebkit-2.24.1.html
 download: https://wpewebkit.org/releases/wpewebkit-2.24.1.tar.xz
 ---

--- a/_posts/2019-05-08-libwpe-1.3.0-released.md
+++ b/_posts/2019-05-08-libwpe-1.3.0-released.md
@@ -2,7 +2,8 @@
 layout: post
 title: "libwpe 1.3.0 released!"
 date: 2019-05-08
-tags: release
+tags: [release, unstable]
+version: 1.3.0
 permalink: /release/libwpe-1.3.0.html
 download: https://wpewebkit.org/releases/libwpe-1.3.0.tar.xz
 ---

--- a/_posts/2019-05-08-wpebackend-fdo-1.3.0-released.md
+++ b/_posts/2019-05-08-wpebackend-fdo-1.3.0-released.md
@@ -2,7 +2,8 @@
 layout: post
 title: "WPEBackend-fdo 1.3.0 released!"
 date: 2019-05-08
-tags: release
+tags: [release, unstable]
+version: 1.3.0
 permalink: /release/wpebackend-fdo-1.3.0.html
 download: https://wpewebkit.org/releases/wpebackend-fdo-1.3.0.tar.xz
 ---

--- a/_posts/2019-05-20-wpewebkit-2.24.2.md
+++ b/_posts/2019-05-20-wpewebkit-2.24.2.md
@@ -2,8 +2,7 @@
 layout: post
 title: WPE WebKit 2.24.2 released!
 version: 2.24.2
-tags: release
-category: stable
+tags: [release, stable]
 permalink: /release/wpewebkit-2.24.2.html
 download: https://wpewebkit.org/releases/wpewebkit-2.24.2.tar.xz
 ---

--- a/_posts/2019-06-13-wpebackend-fdo-1.3.1-released.md
+++ b/_posts/2019-06-13-wpebackend-fdo-1.3.1-released.md
@@ -2,7 +2,8 @@
 layout: post
 title: "WPEBackend-fdo 1.3.1 released!"
 date: 2019-06-13
-tags: release
+tags: [release, unstable]
+version: 1.3.1
 permalink: /release/wpebackend-fdo-1.3.1.html
 download: https://wpewebkit.org/releases/wpebackend-fdo-1.3.1.tar.xz
 ---

--- a/_posts/2019-06-17-libwpe-1.3.1-released.md
+++ b/_posts/2019-06-17-libwpe-1.3.1-released.md
@@ -2,7 +2,8 @@
 layout: post
 title: "libwpe 1.3.1 released!"
 date: 2019-06-17
-tags: release
+tags: [release, unstable]
+version: 1.3.1
 permalink: /release/libwpe-1.3.1.html
 download: https://wpewebkit.org/releases/libwpe-1.3.1.tar.xz
 ---

--- a/_posts/2019-06-19-wpewebkit-2.25.1-released.md
+++ b/_posts/2019-06-19-wpewebkit-2.25.1-released.md
@@ -2,9 +2,8 @@
 layout: post
 title: "WPE WebKit 2.25.1 released!"
 date: 2019-06-19
-tags: release
+tags: [release, unstable]
 version: 2.25.1
-category: unstable
 permalink: /release/wpewebkit-2.25.1.html
 download: https://wpewebkit.org/releases/wpewebkit-2.25.1.tar.xz
 ---

--- a/_posts/2019-07-01-wpebackend-fdo-1.2.1-released.md
+++ b/_posts/2019-07-01-wpebackend-fdo-1.2.1-released.md
@@ -2,7 +2,8 @@
 layout: post
 title: "WPEBackend-fdo 1.2.1 released!"
 date: 2019-07-01
-tags: release
+tags: [release, stable]
+version: 1.2.1
 permalink: /release/wpebackend-fdo-1.2.1.html
 download: https://wpewebkit.org/releases/wpebackend-fdo-1.2.1.tar.xz
 ---

--- a/_posts/2019-08-12-libwpe-1.2.1-released.md
+++ b/_posts/2019-08-12-libwpe-1.2.1-released.md
@@ -2,7 +2,8 @@
 layout: post
 title: "libwpe 1.2.1 released!"
 date: 2019-08-12
-tags: release
+tags: [release, stable]
+version: 1.2.1
 permalink: /release/libwpe-1.2.1.html
 download: https://wpewebkit.org/releases/libwpe-1.2.1.tar.xz
 ---

--- a/_posts/2019-08-12-wpebackend-fdo-1.2.2-released.md
+++ b/_posts/2019-08-12-wpebackend-fdo-1.2.2-released.md
@@ -2,7 +2,8 @@
 layout: post
 title: "WPEBackend-fdo 1.2.2 released!"
 date: 2019-08-12
-tags: release
+tags: [release, stable]
+version: 1.2.2
 permalink: /release/wpebackend-fdo-1.2.2.html
 download: https://wpewebkit.org/releases/wpebackend-fdo-1.2.2.tar.xz
 ---

--- a/_posts/2019-08-13-wpewebkit-2.25.2-released.md
+++ b/_posts/2019-08-13-wpewebkit-2.25.2-released.md
@@ -2,9 +2,8 @@
 layout: post
 title: "WPE WebKit 2.25.2 released!"
 date: 2019-08-13
-tags: release
+tags: [release, unstable]
 version: 2.25.2
-category: unstable
 permalink: /release/wpewebkit-2.25.2.html
 download: https://wpewebkit.org/releases/wpewebkit-2.25.2.tar.xz
 ---

--- a/_posts/2019-08-28-wpewebkit-2.24.3-released.md
+++ b/_posts/2019-08-28-wpewebkit-2.24.3-released.md
@@ -2,8 +2,7 @@
 layout: post
 title: WPE WebKit 2.24.3 released!
 version: 2.24.3
-tags: release
-category: stable
+tags: [release, stable]
 permalink: /release/wpewebkit-2.24.3.html
 download: https://wpewebkit.org/releases/wpewebkit-2.24.3.tar.xz
 ---

--- a/_posts/2019-09-09-libwpe-1.3.91-released.md
+++ b/_posts/2019-09-09-libwpe-1.3.91-released.md
@@ -2,7 +2,8 @@
 layout: post
 title: "libwpe 1.3.91 released!"
 date: 2019-09-09
-tags: release
+tags: [release, unstable]
+version: 1.3.91
 permalink: /release/libwpe-1.3.91.html
 download: https://wpewebkit.org/releases/libwpe-1.3.91.tar.xz
 ---

--- a/_posts/2019-09-09-wpebackend-fdo-1.3.91-released.md
+++ b/_posts/2019-09-09-wpebackend-fdo-1.3.91-released.md
@@ -2,7 +2,8 @@
 layout: post
 title: "WPEBackend-fdo 1.3.91 released!"
 date: 2019-09-09
-tags: release
+tags: [release, unstable]
+version: 1.3.91
 permalink: /release/wpebackend-fdo-1.3.91.html
 download: https://wpewebkit.org/releases/wpebackend-fdo-1.3.91.tar.xz
 ---

--- a/_posts/2019-09-09-wpewebkit-2.25.91-released.md
+++ b/_posts/2019-09-09-wpewebkit-2.25.91-released.md
@@ -2,9 +2,8 @@
 layout: post
 title: "WPE WebKit 2.25.91 released!"
 date: 2019-09-09
-tags: release
+tags: [release, unstable]
 version: 2.25.91
-category: unstable
 permalink: /release/wpewebkit-2.25.91.html
 download: https://wpewebkit.org/releases/wpewebkit-2.25.91.tar.xz
 ---

--- a/index.html
+++ b/index.html
@@ -64,9 +64,9 @@ layout: default
           <strong>Release Announcements</strong>
         </h4>
         {% for post in site.tags.release limit:3 %}
-        <p class="text-faded mb-2">{{ post.date | date_to_string }}: <a href="{{ post.url | prepend: site.baseurl }}"><strong>{{ post.title }}</strong></a></p>
+        <p class="text-faded mb-2">{{ post.date | date_to_string }}: <a href="{{ post.url | absolute_url }}"><strong>{{ post.title }}</strong></a></p>
         {% endfor %}
-        <a href="{{ "/release/" | prepend: site.baseurl }}" class="btn btn-sm btn-light m-3">More&hellip;</a>
+        <a href="{{ '/release/' | absolute_url }}" class="btn btn-sm btn-light m-3">More&hellip;</a>
       </div>
       <div class="col-lg-4 col-md-6 mb-5 mb-md-0">
         <span class="service-icon rounded-circle mx-auto mb-3">
@@ -76,9 +76,9 @@ layout: default
           <strong>Security Advisories</strong>
         </h4>
         {% for post in site.tags.WSA limit:3 %}
-        <p class="text-faded mb-2">{{ post.date | date_to_string }}: <a href="{{ post.url | prepend: site.baseurl }}"><strong>{{ post.title }}</strong></a></p>
+        <p class="text-faded mb-2">{{ post.date | date_to_string }}: <a href="{{ post.url | absolute_url }}"><strong>{{ post.title }}</strong></a></p>
         {% endfor %}
-        <a href="{{ "/security/" | prepend: site.baseurl }}" class="btn btn-sm btn-light m-3">More&hellip;</a>
+        <a href="{{ '/security/' | absolute_url }}" class="btn btn-sm btn-light m-3">More&hellip;</a>
       </div>
       <div class="col-lg-4 col-md-6">
         <span class="service-icon rounded-circle mx-auto mb-3">
@@ -87,7 +87,7 @@ layout: default
         <h4>
           <strong>Documentation</strong>
         </h4>
-		<p class="text-faded mb-0"><a href="{{ "/release/schedule/" | prepend: site.baseurl }}"><strong>Release Schedule</strong></a></p>
+		<p class="text-faded mb-0"><a href="{{ '/release/schedule/' | absolute_url }}"><strong>Release Schedule</strong></a></p>
         <p class="text-faded mb-0"><a href="https://webkit.org/wpe/"><strong>WPE page at webkit.org</strong></a></p>
         <p class="text-faded mb-0"><a href="https://trac.webkit.org/wiki/WPE"><strong>Building and running instructions</strong></a></p>
       </div>

--- a/index.html
+++ b/index.html
@@ -3,30 +3,60 @@ layout: default
 ---
 
 <!-- Header -->
-<header class="masthead d-flex">
+<header class="masthead d-flex p-5">
   <div class="container text-center my-auto">
     <h1 class="mb-1">{{ site.title }}</h1>
-    <h3 class="mb-5">
-      <em>{{ site.subtitle }}</em>
+    <h3 class="mb-4">
+      {{ site.subtitle }}
     </h3>
-    <p class="lead mb-5"><strong>WPE WebKit</strong> allows <strong>embedders</strong> to create simple and performant systems based on <strong>Web</strong> platform technologies. It is designed with hardware acceleration in mind, leveraging common 3D graphics APIs for best <strong>performance</strong>.</p>
-    {% for post in site.categories.stable limit:1 %}
-    <a class="btn btn-primary btn-xl" style="margin: 1rem;" href="{{ post.download }}">Download WPE WebKit {{ post.version }}<br>Latest Stable</a>
-    {% endfor %}
-    {% for post in site.categories.unstable limit:1 %}
-    <a class="btn btn-secondary btn-xl" style="margin: 1rem;" href="{{ post.download }}">Download WPE WebKit {{ post.version }}<br>Latest Unstable</a>
-    {% endfor %}
-  </div>
+    <p class="lead mb-0"><strong>WPE WebKit</strong> allows <strong>embedders</strong> to create simple and performant systems based on <strong>Web</strong> platform technologies. It is designed with hardware acceleration in mind, leveraging common 3D graphics APIs for best <strong>performance</strong>.</p>
 </header>
 
+<!-- Downloads -->
+<section class="content-section text-center bg-dark p-5">
+	<div class="container">
+		<h4 class="text-light mb-3">Downloads</h3>
+		<div class="row mb-2">
+			{% for pkg in site.packages %}
+			<div class="col-lg-4 col-md-6 mb-2 mb-lg-0">
+				<div class="card">
+					<div class="card-header">{{ pkg.name }}</div>
+					<ul class="list-group list-group-flush">
+						{% for kind in site.release_kinds %}
+						{% assign post = site.tags.release
+						 | where_exp:"item", "item.slug contains pkg.slug and item.tags contains kind.tag"
+						 | first %}
+						{% if post %}
+							<a class="list-group-item list-group-item-action d-flex justify-content-between align-items-center"
+									href="{{ '/releases/' | append: pkg.slug | append: '-' | append: post.version |  append: '.tar.xz' | absolute_url }}">
+								{{ kind.tag | capitalize }} <span class="sr-only">version:</span>
+								<span class="badge badge-{{ kind.color }}" href="{{ post.url }}">{{ post.version }}</span>
+							</a>
+						{% endif %}
+						{% endfor %}
+					</ul>
+				</div>
+			</div>
+			{% endfor %}
+		</div>
+
+		<p class="m-3 mt-4">
+			<a class="btn btn-light btn-sm" style="font-weight: normal"
+				href="{{ '/releases/' | absolute_url }}">
+				<i class="icon-cloud-download align-text-bottom"></i>&nbsp;&nbsp;&nbsp;All Downloads&hellip;</a>
+		</p>
+	  </div>
+  </div>
+</section>
+
 <!-- Resources -->
-<section class="content-section bg-primary text-white text-center" id="resources">
+<section class="content-section bg-primary text-white text-center p-6" id="resources">
   <div class="container">
     <div class="content-section-heading">
       <h2 class="mb-5">Resources</h2>
     </div>
     <div class="row">
-      <div class="col-lg-3 col-md-6 mb-5 mb-lg-0">
+      <div class="col-lg-4 col-md-6 mb-5 mb-lg-0">
         <span class="service-icon rounded-circle mx-auto mb-3">
           <i class="icon-note"></i>
         </span>
@@ -38,19 +68,7 @@ layout: default
         {% endfor %}
         <a href="{{ "/release/" | prepend: site.baseurl }}" class="btn btn-sm btn-light m-3">More&hellip;</a>
       </div>
-      <div class="col-lg-3 col-md-6 mb-5 mb-lg-0">
-        <span class="service-icon rounded-circle mx-auto mb-3">
-          <i class="icon-cloud-download"></i>
-        </span>
-        <h4>
-          <strong>Downloads</strong>
-        </h4>
-        {% for post in site.tags.release limit:3 %}
-        <p class="text-faded mb-2">{{ post.date | date_to_string }}: <a href="{{ post.download }}"><strong>WPE WebKit {{ post.version }} {{ post.category | capitalize }}</strong></a></p>
-        {% endfor %}
-        <a href="{{ "/releases/" | prepend: site.baseurl }}" class="btn btn-sm btn-light m-3">More&hellip;</a>
-      </div>
-      <div class="col-lg-3 col-md-6 mb-5 mb-md-0">
+      <div class="col-lg-4 col-md-6 mb-5 mb-md-0">
         <span class="service-icon rounded-circle mx-auto mb-3">
           <i class="icon-lock"></i>
         </span>
@@ -62,7 +80,7 @@ layout: default
         {% endfor %}
         <a href="{{ "/security/" | prepend: site.baseurl }}" class="btn btn-sm btn-light m-3">More&hellip;</a>
       </div>
-      <div class="col-lg-3 col-md-6">
+      <div class="col-lg-4 col-md-6">
         <span class="service-icon rounded-circle mx-auto mb-3">
           <i class="icon-docs"></i>
         </span>

--- a/release/index.html
+++ b/release/index.html
@@ -17,12 +17,12 @@ title: WPE WebKit - Release Announcements
       <div class="col-lg-10 mx-auto lead text-left">
         {% for post in site.tags.release %}
         <p>
-        <h3><a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a></h3>
+        <h3><a href="{{ post.url | absolute_url }}">{{ post.title }}</a></h3>
         {{ post.date | date_to_string }}
         </p>
         {% endfor %}
 
-        <p class="text-right"><a class="btn btn-primary" href="{{ "/" | prepend: site.baseurl }}"><i class="icon-home mr-1"></i> Home</a></p>
+        <p class="text-right"><a class="btn btn-primary" href="{{ '/' | absolute_url }}"><i class="icon-home mr-1"></i> Home</a></p>
       </div>
     </div>
   </div>

--- a/scss/_tables.scss
+++ b/scss/_tables.scss
@@ -15,4 +15,3 @@ table {
 		background: #efefef;
 	}
 }
-

--- a/security/index.html
+++ b/security/index.html
@@ -17,12 +17,12 @@ title: WPE WebKit - Security Advisories
       <div class="col-lg-10 mx-auto lead text-left">
         {% for post in site.tags.WSA %}
         <p>
-        <h3><a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a></h3>
+        <h3><a href="{{ post.url | absolute_url }}">{{ post.title }}</a></h3>
         {{ post.date | date_to_string }}
         </p>
         {% endfor %}
 
-        <p class="text-right"><a class="btn btn-primary" href="{{ "/" | prepend: site.baseurl }}"><i class="icon-home mr-1"></i> Home</a></p>
+        <p class="text-right"><a class="btn btn-primary" href="{{ '/' | absolute_url }}"><i class="icon-home mr-1"></i> Home</a></p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Instead of having two buttons for downloading the stable and unstable WPE WebKit packaged releases, change it into a table with rows for all the components (WPE WebKit, libwpe, WPEBackend-fdo), and columns for the stable and unstable releases.

This makes the top of the front page now look as follows:

![Screenshot with the changes applied](https://user-images.githubusercontent.com/723451/64893109-f1a73000-d67e-11e9-9b19-a464fe1c8eca.png)


As a bonus, use the `absolute_url` filter instead of bare string concatenations with the `append:` filter wherever possible, for additional robustness.