### PR TITLE
CI: Import actions to deploy to the live site

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,40 @@
+name: deploy
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '14.x'
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Cache Node modules
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: npm-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            npm-${{ runner.os }}-
+            npm-
+      - name: Install Node modules
+        run: npm install
+      - name: Eleventy
+        run: |
+          ./node_modules/.bin/eleventy --output='_site/' --pathprefix='/'
+      - name: Deploy
+        uses: easingthemes/ssh-deploy@v2.1.1
+        with:
+          ARGS: -azz --info=stats2
+          SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+          REMOTE_USER: ${{ secrets.DEPLOY_REMOTE_USER }}
+          REMOTE_HOST: ${{ secrets.DEPLOY_REMOTE_HOST }}
+          REMOTE_PORT: ${{ secrets.DEPLOY_REMOTE_PORT }}
+          TARGET: ${{ secrets.DEPLOY_REMOTE_PATH }}
+          SOURCE: _site/


### PR DESCRIPTION
Add a GitHub Actions job file which gets triggered on pushes to the `master` branch, which will cause the site to be built and deployed to the live server using rsync over SSH.

The details used to connect to the server (SSH key, host, port, path) are hidden from the Actions configuration using repository secrets to avoid them being publicly visible in the repository.