### PR TITLE
Small fixes for the about/code.md page

### DIFF
--- a/about/code.md
+++ b/about/code.md
@@ -14,7 +14,8 @@ You can learn a great deal about how you can contribute upstream to WebKit throu
 Having issues with Cog?  <a href="https://github.com/Igalia/cog">Report a Cog issue.</a>
 
 ## Source
-There is, of course, <a href="https://webkit.org/getting-the-code/">WPE WebKit source</a> itself, but there are several supporting repositories as well...
+
+There is, of course, <a href="https://webkit.org/getting-the-code/">WPE WebKit source</a> itself, but there are several supporting repositories as well:
 
 * <a href="https://github.com/Igalia/cog">Cog</a>: A small single “window” launcher for the WebKit WPE port, with no user interface, suitable to be used as a Web application container. 
 

--- a/about/code.md
+++ b/about/code.md
@@ -23,7 +23,7 @@ There is, of course, <a href="https://webkit.org/getting-the-code/">WPE WebKit s
 
 * <a href="https://github.com/WebPlatformForEmbedded/libwpe">libwpe</a>: General-purpose library for WPE.
 
-With each new release of WPE, we make source tarballs available as well...
+With each new release of WPE, we make source tarballs available.
 
 <style>.card { margin-bottom: 2rem; } #about-code-section { margin-bottom: 2rem; }  #about-code-section ul { list-style-type: none; }</style>
 <section id="about-code-section" class="content-section text-center bg-dark p-5">

--- a/about/code.md
+++ b/about/code.md
@@ -14,7 +14,7 @@ You can learn a great deal about how you can contribute upstream to WebKit throu
 Having issues with Cog?  <a href="https://github.com/Igalia/cog">Report a Cog issue.</a>
 
 ## Source
-There is, of course, <a href="https://github.com/WebPlatformForEmbedded/WPEWebKit">WPE WebKit source</a> itself, but there are several supporting repositories as well...
+There is, of course, <a href="https://webkit.org/getting-the-code/">WPE WebKit source</a> itself, but there are several supporting repositories as well...
 
 * <a href="https://github.com/Igalia/cog">Cog</a>: A small single “window” launcher for the WebKit WPE port, with no user interface, suitable to be used as a Web application container. 
 


### PR DESCRIPTION
Namely:

- Link to the webkit.org site for WebKit sources, which is *THE* canonical place to look.
- Replace ellipsis with colon before bullet list. It was odd that this paragraph was ending with “…” if what comes right after is a list of things.
- Remove one “as well” almost immediately after another. Two paragraphs ending with the same expression next to each other didn't read great. Removed the unnecessary ellipsis as well (pun intended).
