### PR TITLE
11ty: Tweak markdown-it options

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -26,8 +26,9 @@ module.exports = function(eleventyConfig) {
   })
 
   eleventyConfig.setLibrary("md", MarkdownIt({
-	  linkify: true,
-	  breaks: true,
+	  typographer: true,
+	  linkify: false,
+	  breaks: false,
 	  html: true,
 	}).use(MarkdownItAnchor, {
 	  level: 2,


### PR DESCRIPTION
Enabling `typographer` automatically converts double- and single-quotes into their typographic variants (`“”` and `‘’`), resulting in more polished looking output.

Disabling the `linkify` option prevents link to from being automatically generated, which solves issues like the `i.MX` string being turned into a link to `http://i.mx`. It is better to explicitly insert links using Markdown or HTML syntax when needed.

The reason to disable the `breaks` option is that otherwise line breaks generate `<br>` elements, which is not standard Markdown and results in unexpected output when source files are line-wrapped.