### PR TITLE
CI: Add a CODEOWNERS file to auto-assign reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Reference:
+#   https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+# Default reviewers
+*  @bkardell
+
+# The following rules override the defaults
+/.eleventy.js        @aperezdc @bkardell
+/.github/workflows/  @aperezdc


### PR DESCRIPTION
Import a `CODEOWNERS` file, which instructs GitHub to assign default reviewers to new PRs based on which files are being changed by the PR.

----

Site preview: https://igalia.github.io/wpewebkit.org/aperez/add-codeowners/