### PR TITLE
code: Add section with contact information

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,31 +1,3 @@
-<!-- Contact -->
-<section class="content-section bg-dark text-white text-center" id="contact">
-  <div class="container text-center">
-    <div class="row">
-      <div class="col-lg-10 mx-auto">
-        <h2>Contact</h2>
-      </div>
-    </div>
-    <ul class="list-inline mb-5 lead">
-      <li class="list-inline-item">
-        <a class="social-link rounded-circle text-white mr-3" href="https://twitter.com/WPEWebKit">
-          <i class="icon-social-twitter mr-1"></i> @WPEWebKit
-        </a>
-      </li>
-      <li class="list-inline-item">
-        <a class="social-link rounded-circle text-white" href="https://lists.webkit.org/mailman/listinfo/webkit-wpe">
-          <i class="icon-envelope mr-1"></i> webkit-wpe@lists.webkit.org
-        </a>
-      </li>
-      <li class="list-inline-item">
-        <a class="social-link rounded-circle text-white ml-3" href="https://webchat.freenode.net/?channels=#webkit">
-          <i class="icon-people mr-1"></i> #webkit on freenode
-        </a>
-      </li>
-    </ul>
-  </div>
-</section>
-
 <!-- Footer -->
 <footer class="footer">
   <a class="navbar-brand" href="/"><img width="200" src="{{ '/assets/svg/blue_Web_Logo.svg' | url }}"></a>

--- a/about/code.md
+++ b/about/code.md
@@ -14,6 +14,18 @@ You can learn a great deal about how you can contribute upstream to WebKit throu
 * Found an issue with WPE? [Report a WebKit issue](http://bugs.webkit.org).
 * Having issues with Cog? [Report a Cog issue](https://github.com/Igalia/cog).
 
+## Contact
+
+For questions and hanging out you can find us here:
+
+* [#wpe:matrix.org](https://matrix.to/#/#wpe:matrix.org) room on
+  [Matrix](https://matrix.org).
+* [#wpe](https://webchat.freenode.net/?channels=wpe) channel on
+  [Freenode](https://freenode.net).
+* [webkit-wpe](https://lists.webkit.org/mailman/listinfo/webkit-wpe) mailing
+  list.
+* [@WPEWebKit](https://twitter.com/WPEWebKit) on Twitter.
+
 ## Source
 
 There is, of course, the [WPE WebKit source](https://webkit.org/getting-the-code/) itself, but there are several supporting repositories as well:


### PR DESCRIPTION
Mention the chat rooms (both on Matrix and Freenode), the mailing list, and Twitter.

This also removes the “Contact” box from the footer, which is now unneeded.

Fixes #21

----

Site preview: https://igalia.github.io/wpewebkit.org/aperez/add-contact/