### PR TITLE
Bring back the download buttons for release pages

### DIFF
--- a/_data/site.json
+++ b/_data/site.json
@@ -1,0 +1,3 @@
+{
+	"release_dir": "https://wpewebkit.org/releases/"
+}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -17,7 +17,7 @@
 
   <!-- Custom Fonts -->
   <link rel="stylesheet" href="{{ '/vendor/font-awesome/css/font-awesome.min.css' | url }}">
-  <link rel="stylesheet" href="{{ '/vendor/simple-line-icons/css/simple-line-icons.css' | absolute_url }}">
+  <link rel="stylesheet" href="{{ '/vendor/simple-line-icons/css/simple-line-icons.css' | url }}">
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700,300italic,400italic,700italic" rel="stylesheet" type="text/css">
 
   <!-- Custom CSS -->

--- a/_includes/post.html
+++ b/_includes/post.html
@@ -24,7 +24,7 @@ layout: page
 
         {{ content }}
 
-        <p class="text-right"><a class="btn btn-primary" href="{{ '/' | absolute_url }}"><i class="icon-home mr-1"></i> Home</a></p>
+        <p class="text-right"><a class="btn btn-primary" href="{{ '/' | url }}"><i class="icon-home mr-1"></i> Home</a></p>
       </div>
     </div>
   </div>

--- a/_includes/post.html
+++ b/_includes/post.html
@@ -8,10 +8,10 @@ layout: page
         <h3 class="text-secondary mb-0">{{ page.date | dateString }}</h3>
       {% endif %}
       <h2>{{ title }}</h2>
-	  {% if page.downloa %}
-	  <a class="btn btn-xl btn-secondary mt-3" href="{{ page.download }}">Download</a>
-	  {% elsif page.package and page.version %}
-	  <a class="btn btn-xl btn-secondary mt-3" href="{{ site.release_dir | append:'/' | append: page.package | append: '-' | append: page.version | append: '.tar.xz' | absolute_url }}">Download</a>
+	  {% if download %}
+	  <a class="btn btn-xl btn-secondary mt-3" href="{{ download }}">Download</a>
+	  {% elsif package and version %}
+	  <a class="btn btn-xl btn-secondary mt-3" href="{{ site.release_dir | append:'/' | append: package | append: '-' | append: version | append: '.tar.xz' | url }}">Download</a>
 	  {% endif %}
     </div>
   </div>


### PR DESCRIPTION
After the move to Eleventy, pages for releases (and others including a link in the `download` front matter data element) have been missing the download buttons.

This brings them back, by adding a `site.json` global data file to allow continue using `{% site.release_dir %}` in templates, and adapts the post template.

----

Site preview: https://igalia.github.io/wpewebkit.org/aperezdc/dlbuttons/