### PR TITLE
Update release compatibility table for WPE WebKit 2.30.x

### DIFF
--- a/release/schedule/index.md
+++ b/release/schedule/index.md
@@ -50,13 +50,14 @@ version number stays the same:
 The following table summarizes which *stable* releases of libwpe, WPE WebKit,
 WPEBackend-fdo, and Cog are compatible and tested with each other.
 
-| **WPE WebKit** | **libwpe** | **WPEBackend-fdo** | **Cog** |
-|:--------------:|:----------:|:------------------:|:-------:|
-| 2.28.x         | 1.6.x      | 1.6.x              | 0.6.x   |
-| 2.26.x         | 1.4.x      | 1.4.x              | 0.4.x   |
-| 2.24.x         | 1.2.x      | 1.2.x              | 0.3.x   |
-| 2.22.x         | 1.0.x      | 1.0.x              | 0.2.x   |
-| 2.20.x         | \< 1.0.0   | \< 1.0.0           | ≤ 0.1.x |
+| **WPE WebKit** | **libwpe**   | **WPEBackend-fdo** | **Cog**      |
+|:--------------:|:------------:|:------------------:|:------------:|
+| 2.30.x         | 1.8.x, 1.6.x | 1.8.x              | 0.8.x, 0.6.x |
+| 2.28.x         | 1.6.x        | 1.6.x              | 0.8.x, 0.6.x |
+| 2.26.x         | 1.4.x        | 1.4.x              | 0.4.x        |
+| 2.24.x         | 1.2.x        | 1.2.x              | 0.3.x        |
+| 2.22.x         | 1.0.x        | 1.0.x              | 0.2.x        |
+| 2.20.x         | \< 1.0.0     | \< 1.0.0           | ≤ 0.1.x      |
 
 Distributors and packagers are strongly advised to use the versions above.
 


### PR DESCRIPTION
SSIA

----

We would want to have this merged soon because it adds WPE WebKit 2.30.x to the compatibility table, and the first stable release in the series will be done in the next weeks.

Related: it would be good to do a fix for #35 as well.

----

Site preview: https://igalia.github.io/wpewebkit.org/aperezdc/update-release-compat/

----

Site preview: https://igalia.github.io/wpewebkit.org/aperezdc/update-release-compat/