### PR TITLE
Link releases schedule page from drop-down menu

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -20,10 +20,9 @@
           <a class="dropdown-item" href="{{ '/about/exploring.html' | url }}">Explore WPE / Embedded</a>
           <a class="dropdown-item" href="{{ '/about/supported-hardware.html' | url }}">Supported Hardware</a>
           <a class="dropdown-item" href="{{ '/about/a-good-choice.html' | url }}">Why Choose WPE</a>
-          
-          
           <div class="dropdown-divider"></div>
           <a class="dropdown-item" href="{{ '/about/builds.html' | url }}">Build it</a>
+          <a class="dropdown-item" href="{{ '/release/schedule' | url }}">Release Schedule</a>
         </div>
       </li>
       <li class="nav-item active">


### PR DESCRIPTION
Add one more entry in the “Documentation” drop-down menu linking to the releases schedule page.

Fixes #35

----

Site preview: https://igalia.github.io/wpewebkit.org/aperezdc/releases-page-link/