### PR TITLE
package.json: Add "serve" scriptlet

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ In order to setup, you just just have to check it out, switch to the checked out
 
 In order to test it all you need to do is 
 
-    npx eleventy --serve
-
+```sh
+npm install && npm run serve
+```
 
 This will build the project, start a server, and your terminal will provide you useful links to actually get to it.
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "eleventy",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "serve": "eleventy --serve --quiet --pathprefix=/",
     "deploy-dev": "gh-pages -d _site"
   },
   "repository": {


### PR DESCRIPTION
Add a `serve` scriptlet. This allows running `npm run serve` and not needing to remember the Eleventy command for local development. The `README.md` file is updated accordingly.

----

Site preview: https://igalia.github.io/wpewebkit.org/aperezdc/misc-npm-updates/