### PR TITLE
Added package data field to files before September 2019…

### DIFF
--- a/_posts/2018-07-09-wpebackend-0.2.0-released.md
+++ b/_posts/2018-07-09-wpebackend-0.2.0-released.md
@@ -4,6 +4,7 @@ title: "WPEBackend 0.2.0 released!"
 date: 2018-07-09
 tags: [release, stable]
 version: 0.2.0
+package: wpebackend-fdo
 permalink: /release/wpebackend-0.2.0.html
 download: https://wpewebkit.org/releases/wpebackend-0.2.0.tar.xz
 ---

--- a/_posts/2018-08-21-libwpe-1.0.0-released.md
+++ b/_posts/2018-08-21-libwpe-1.0.0-released.md
@@ -4,6 +4,7 @@ title: "libwpe 1.0.0 released!"
 date: 2018-08-21
 tags: [release, stable]
 version: 1.0.0
+package: libwpe
 permalink: /release/libwpe-1.0.0.html
 download: https://wpewebkit.org/releases/libwpe-1.0.0.tar.xz
 ---

--- a/_posts/2018-08-21-wpebackend-fdo-1.0.0-released.md
+++ b/_posts/2018-08-21-wpebackend-fdo-1.0.0-released.md
@@ -4,6 +4,7 @@ title: "WPEBackend-fdo 1.0.0 released!"
 date: 2018-08-21
 tags: [release, stable]
 version: 1.0.0
+package: wpebackend-fdo
 permalink: /release/wpebackend-fdo-1.0.0.html
 download: https://wpewebkit.org/releases/wpebackend-fdo-1.0.0.tar.xz
 ---

--- a/_posts/2018-11-06-wpewebkit-2.22.1-released.md
+++ b/_posts/2018-11-06-wpewebkit-2.22.1-released.md
@@ -4,6 +4,7 @@ title: "WPE WebKit 2.22.1 released!"
 version: 2.22.1
 date: 2018-11-06
 tags: [release, stable]
+package: wpewebkit
 permalink: /release/wpe-2.22.1.html
 download: https://wpewebkit.org/releases/wpewebkit-2.22.1.tar.xz
 ---

--- a/_posts/2018-11-21-wpewebkit-2.22.2-released.md
+++ b/_posts/2018-11-21-wpewebkit-2.22.2-released.md
@@ -4,6 +4,7 @@ title: "WPE WebKit 2.22.2 released!"
 version: 2.22.2
 date: 2018-11-21
 tags: [release, stable]
+package: wpewebkit
 permalink: /release/wpe-2.22.2.html
 download: https://wpewebkit.org/releases/wpewebkit-2.22.2.tar.xz
 ---

--- a/_posts/2018-12-13-libwpe-1.1.0-released.md
+++ b/_posts/2018-12-13-libwpe-1.1.0-released.md
@@ -4,6 +4,7 @@ title: "libwpe 1.1.0 released!"
 date: 2018-12-13
 tags: [release, unstable]
 version: 1.1.0
+package: libwpe
 permalink: /release/libwpe-1.1.0.html
 download: https://wpewebkit.org/releases/libwpe-1.1.0.tar.xz
 ---

--- a/_posts/2018-12-13-wpewebkit-2.22.3-released.md
+++ b/_posts/2018-12-13-wpewebkit-2.22.3-released.md
@@ -3,6 +3,7 @@ layout: post
 title: "WPE WebKit 2.22.3 released!"
 version: 2.22.3
 tags: [release, stable]
+package: wpewebkit
 permalink: /release/wpe-2.22.3.html
 download: https://wpewebkit.org/releases/wpewebkit-2.22.3.tar.xz
 ---

--- a/_posts/2018-12-14-wpebackend-fdo-1.1.0-released.md
+++ b/_posts/2018-12-14-wpebackend-fdo-1.1.0-released.md
@@ -4,6 +4,7 @@ title: "WPEBackend-fdo 1.1.0 released!"
 date: 2018-12-14
 tags: [release, unstable]
 version: 1.1.0
+package: wpebackend-fdo
 permalink: /release/wpebackend-fdo-1.1.0.html
 download: https://wpewebkit.org/releases/wpebackend-fdo-1.1.0.tar.xz
 ---

--- a/_posts/2019-01-06-wpebackend-fdo-1.0.1-released.md
+++ b/_posts/2019-01-06-wpebackend-fdo-1.0.1-released.md
@@ -4,6 +4,7 @@ title: "WPEBackend-fdo 1.0.1 released!"
 date: 2019-01-06
 tags: [release, stable]
 version: 1.0.1
+package: wpebackend-fdo
 permalink: /release/wpebackend-fdo-1.0.1.html
 download: https://wpewebkit.org/releases/wpebackend-fdo-1.0.1.tar.xz
 ---

--- a/_posts/2019-02-09-wpewebkit-2.22.4-released.md
+++ b/_posts/2019-02-09-wpewebkit-2.22.4-released.md
@@ -3,6 +3,7 @@ layout: post
 title: "WPE WebKit 2.22.4 released!"
 version: 2.22.4
 tags: [release, stable]
+package: wpewebkit
 permalink: /release/wpe-2.22.4.html
 download: https://wpewebkit.org/releases/wpewebkit-2.22.4.tar.xz
 ---

--- a/_posts/2019-02-21-wpewebkit-2.23.90-released.md
+++ b/_posts/2019-02-21-wpewebkit-2.23.90-released.md
@@ -3,6 +3,7 @@ layout: post
 title: WPE WebKit 2.23.90 released!
 version: 2.23.90
 tags: [release, unstable]
+package: wpewebkit
 permalink: /release/wpewebkit-2.23.90.html
 download: https://wpewebkit.org/releases/wpewebkit-2.23.90.tar.xz
 ---

--- a/_posts/2019-02-26-wpebackend-fdo-1.1.90.md
+++ b/_posts/2019-02-26-wpebackend-fdo-1.1.90.md
@@ -4,6 +4,7 @@ title: "WPEBackend-fdo 1.1.90 released!"
 date: 2019-02-26
 tags: [release, unstable]
 version: 1.1.90
+package: wpebackend-fdo
 permalink: /release/wpebackend-fdo-1.1.90.html
 download: https://wpewebkit.org/releases/wpebackend-fdo-1.1.90.tar.xz
 ---

--- a/_posts/2019-03-01-wpewebkit-2.22.5-released.md
+++ b/_posts/2019-03-01-wpewebkit-2.22.5-released.md
@@ -3,6 +3,7 @@ layout: post
 title: "WPE WebKit 2.22.5 released!"
 version: 2.22.5
 tags: [release, stable]
+package: wpewebkit
 permalink: /release/wpe-2.22.5.html
 download: https://wpewebkit.org/releases/wpewebkit-2.22.5.tar.xz
 ---

--- a/_posts/2019-03-04-libwpe-1.1.90-released.md
+++ b/_posts/2019-03-04-libwpe-1.1.90-released.md
@@ -4,6 +4,7 @@ title: "libwpe 1.1.90 released!"
 date: 2019-03-04
 tags: [release, unstable]
 version: 1.1.90
+package: libwpe
 permalink: /release/libwpe-1.1.90.html
 download: https://wpewebkit.org/releases/libwpe-1.1.90.tar.xz
 ---

--- a/_posts/2019-03-14-wpebackend-fdo-1.1.91.md
+++ b/_posts/2019-03-14-wpebackend-fdo-1.1.91.md
@@ -4,6 +4,7 @@ title: "WPEBackend-fdo 1.1.91 released!"
 date: 2019-03-14
 tags: [release, unstable]
 version: 1.1.91
+package: wpebackend-fdo
 permalink: /release/wpebackend-fdo-1.1.91.html
 download: https://wpewebkit.org/releases/wpebackend-fdo-1.1.91.tar.xz
 ---

--- a/_posts/2019-03-18-wpewebkit-2.23.91.md
+++ b/_posts/2019-03-18-wpewebkit-2.23.91.md
@@ -3,6 +3,7 @@ layout: post
 title: WPE WebKit 2.23.91 released!
 version: 2.23.91
 tags: [release, unstable]
+package: wpewebkit
 permalink: /release/wpewebkit-2.23.91.html
 download: https://wpewebkit.org/releases/wpewebkit-2.23.91.tar.xz
 ---

--- a/_posts/2019-03-26-libwpe-1.2.0-released.md
+++ b/_posts/2019-03-26-libwpe-1.2.0-released.md
@@ -4,6 +4,7 @@ title: "libwpe 1.2.0 released!"
 date: 2019-03-26
 tags: [release, stable]
 version: 1.2.0
+package: libwpe
 permalink: /release/libwpe-1.2.0.html
 download: https://wpewebkit.org/releases/libwpe-1.2.0.tar.xz
 ---

--- a/_posts/2019-03-26-wpebackend-fdo-1.2.0.md
+++ b/_posts/2019-03-26-wpebackend-fdo-1.2.0.md
@@ -4,6 +4,7 @@ title: "WPEBackend-fdo 1.2.0 released!"
 date: 2019-03-26
 tags: [release, stable]
 version: 1.2.0
+package: wpebackend-fdo
 permalink: /release/wpebackend-fdo-1.2.0.html
 download: https://wpewebkit.org/releases/wpebackend-fdo-1.2.0.tar.xz
 ---

--- a/_posts/2019-03-27-wpewebkit-2.24.0.md
+++ b/_posts/2019-03-27-wpewebkit-2.24.0.md
@@ -3,6 +3,7 @@ layout: post
 title: WPE WebKit 2.24.0 released!
 version: 2.24.0
 tags: [release, stable]
+package: wpewebkit
 permalink: /release/wpewebkit-2.24.0.html
 download: https://wpewebkit.org/releases/wpewebkit-2.24.0.tar.xz
 ---

--- a/_posts/2019-04-19-wpewebkit-2.24.1.md
+++ b/_posts/2019-04-19-wpewebkit-2.24.1.md
@@ -3,6 +3,7 @@ layout: post
 title: WPE WebKit 2.24.1 released!
 version: 2.24.1
 tags: [release, stable]
+package: wpewebkit
 permalink: /release/wpewebkit-2.24.1.html
 download: https://wpewebkit.org/releases/wpewebkit-2.24.1.tar.xz
 ---

--- a/_posts/2019-05-08-libwpe-1.3.0-released.md
+++ b/_posts/2019-05-08-libwpe-1.3.0-released.md
@@ -4,6 +4,7 @@ title: "libwpe 1.3.0 released!"
 date: 2019-05-08
 tags: [release, unstable]
 version: 1.3.0
+package: libwpe
 permalink: /release/libwpe-1.3.0.html
 download: https://wpewebkit.org/releases/libwpe-1.3.0.tar.xz
 ---

--- a/_posts/2019-05-08-wpebackend-fdo-1.3.0-released.md
+++ b/_posts/2019-05-08-wpebackend-fdo-1.3.0-released.md
@@ -4,6 +4,7 @@ title: "WPEBackend-fdo 1.3.0 released!"
 date: 2019-05-08
 tags: [release, unstable]
 version: 1.3.0
+package: wpebackend-fdo
 permalink: /release/wpebackend-fdo-1.3.0.html
 download: https://wpewebkit.org/releases/wpebackend-fdo-1.3.0.tar.xz
 ---

--- a/_posts/2019-05-20-wpewebkit-2.24.2.md
+++ b/_posts/2019-05-20-wpewebkit-2.24.2.md
@@ -3,6 +3,7 @@ layout: post
 title: WPE WebKit 2.24.2 released!
 version: 2.24.2
 tags: [release, stable]
+package: wpewebkit
 permalink: /release/wpewebkit-2.24.2.html
 download: https://wpewebkit.org/releases/wpewebkit-2.24.2.tar.xz
 ---

--- a/_posts/2019-06-13-wpebackend-fdo-1.3.1-released.md
+++ b/_posts/2019-06-13-wpebackend-fdo-1.3.1-released.md
@@ -4,6 +4,7 @@ title: "WPEBackend-fdo 1.3.1 released!"
 date: 2019-06-13
 tags: [release, unstable]
 version: 1.3.1
+package: wpebackend-fdo
 permalink: /release/wpebackend-fdo-1.3.1.html
 download: https://wpewebkit.org/releases/wpebackend-fdo-1.3.1.tar.xz
 ---

--- a/_posts/2019-06-17-libwpe-1.3.1-released.md
+++ b/_posts/2019-06-17-libwpe-1.3.1-released.md
@@ -4,6 +4,7 @@ title: "libwpe 1.3.1 released!"
 date: 2019-06-17
 tags: [release, unstable]
 version: 1.3.1
+package: libwpe
 permalink: /release/libwpe-1.3.1.html
 download: https://wpewebkit.org/releases/libwpe-1.3.1.tar.xz
 ---

--- a/_posts/2019-06-19-wpewebkit-2.25.1-released.md
+++ b/_posts/2019-06-19-wpewebkit-2.25.1-released.md
@@ -4,6 +4,7 @@ title: "WPE WebKit 2.25.1 released!"
 date: 2019-06-19
 tags: [release, unstable]
 version: 2.25.1
+package: wpewebkit
 permalink: /release/wpewebkit-2.25.1.html
 download: https://wpewebkit.org/releases/wpewebkit-2.25.1.tar.xz
 ---

--- a/_posts/2019-07-01-wpebackend-fdo-1.2.1-released.md
+++ b/_posts/2019-07-01-wpebackend-fdo-1.2.1-released.md
@@ -4,6 +4,7 @@ title: "WPEBackend-fdo 1.2.1 released!"
 date: 2019-07-01
 tags: [release, stable]
 version: 1.2.1
+package: wpebackend-fdo
 permalink: /release/wpebackend-fdo-1.2.1.html
 download: https://wpewebkit.org/releases/wpebackend-fdo-1.2.1.tar.xz
 ---

--- a/_posts/2019-08-12-libwpe-1.2.1-released.md
+++ b/_posts/2019-08-12-libwpe-1.2.1-released.md
@@ -4,6 +4,7 @@ title: "libwpe 1.2.1 released!"
 date: 2019-08-12
 tags: [release, stable]
 version: 1.2.1
+package: libwpe
 permalink: /release/libwpe-1.2.1.html
 download: https://wpewebkit.org/releases/libwpe-1.2.1.tar.xz
 ---

--- a/_posts/2019-08-12-wpebackend-fdo-1.2.2-released.md
+++ b/_posts/2019-08-12-wpebackend-fdo-1.2.2-released.md
@@ -4,6 +4,7 @@ title: "WPEBackend-fdo 1.2.2 released!"
 date: 2019-08-12
 tags: [release, stable]
 version: 1.2.2
+package: wpebackend-fdo
 permalink: /release/wpebackend-fdo-1.2.2.html
 download: https://wpewebkit.org/releases/wpebackend-fdo-1.2.2.tar.xz
 ---

--- a/_posts/2019-08-13-wpewebkit-2.25.2-released.md
+++ b/_posts/2019-08-13-wpewebkit-2.25.2-released.md
@@ -4,6 +4,7 @@ title: "WPE WebKit 2.25.2 released!"
 date: 2019-08-13
 tags: [release, unstable]
 version: 2.25.2
+package: wpewebkit
 permalink: /release/wpewebkit-2.25.2.html
 download: https://wpewebkit.org/releases/wpewebkit-2.25.2.tar.xz
 ---

--- a/_posts/2019-08-28-wpewebkit-2.24.3-released.md
+++ b/_posts/2019-08-28-wpewebkit-2.24.3-released.md
@@ -3,6 +3,7 @@ layout: post
 title: WPE WebKit 2.24.3 released!
 version: 2.24.3
 tags: [release, stable]
+package: wpewebkit
 permalink: /release/wpewebkit-2.24.3.html
 download: https://wpewebkit.org/releases/wpewebkit-2.24.3.tar.xz
 ---

--- a/_posts/2019-09-09-libwpe-1.3.91-released.md
+++ b/_posts/2019-09-09-libwpe-1.3.91-released.md
@@ -4,6 +4,7 @@ title: "libwpe 1.3.91 released!"
 date: 2019-09-09
 tags: [release, unstable]
 version: 1.3.91
+package: libwpe
 permalink: /release/libwpe-1.3.91.html
 download: https://wpewebkit.org/releases/libwpe-1.3.91.tar.xz
 ---

--- a/_posts/2019-09-09-wpebackend-fdo-1.3.91-released.md
+++ b/_posts/2019-09-09-wpebackend-fdo-1.3.91-released.md
@@ -4,6 +4,7 @@ title: "WPEBackend-fdo 1.3.91 released!"
 date: 2019-09-09
 tags: [release, unstable]
 version: 1.3.91
+package: wpebackend-fdo
 permalink: /release/wpebackend-fdo-1.3.91.html
 download: https://wpewebkit.org/releases/wpebackend-fdo-1.3.91.tar.xz
 ---

--- a/_posts/2019-09-09-wpewebkit-2.25.91-released.md
+++ b/_posts/2019-09-09-wpewebkit-2.25.91-released.md
@@ -4,6 +4,7 @@ title: "WPE WebKit 2.25.91 released!"
 date: 2019-09-09
 tags: [release, unstable]
 version: 2.25.91
+package: wpewebkit
 permalink: /release/wpewebkit-2.25.91.html
 download: https://wpewebkit.org/releases/wpewebkit-2.25.91.tar.xz
 ---

--- a/index.html
+++ b/index.html
@@ -177,6 +177,7 @@ description: WebKit port optimized for embedded devices
     display: grid;
     align-content: center;
     z-index: 1;
+    box-shadow: none;
   }
 
 


### PR DESCRIPTION
…which lacked that information.  This is necessary for some of the enhancements requested for the Releases page, and also just keeps things cleaner.

----

Site preview: https://igalia.github.io/wpewebkit.org/data-cleanup/