### PR TITLE
Editorial fixes

### DIFF
--- a/about/a-good-choice.md
+++ b/about/a-good-choice.md
@@ -6,9 +6,9 @@ data: { dateless: "true" }
 permalink: /about/a-good-choice.html
 ---
 
-WPE WebKit is widely adopted in many industries, from digital signage, professional audio, video and broadcasting, home appliances, set-top-boxes, and automotive to inflight infotainment. Countless devices deployed all around the globe are already using WPE WebKit as their web runtime platform and use is growing rapidly.
+WPE WebKit is widely adopted in many industries, including digital signage, professional audio, video and broadcasting, home appliances, set-top boxes, and automotive to in-flight infotainment. Countless devices deployed all around the globe are already using WPE WebKit as their web runtime platform, and use is growing rapidly.
 
-If you need a fast and lightweight web runtime for embedded devices that supports most of the web standards, has hardware acceleration wherever it is advantageous, and has a strong focus on multimedia applications, WPE WebKit is a great choice.
+If you need a fast and lightweight web runtime for embedded devices that supports most current web standards, has hardware acceleration wherever it is advantageous, and has a strong focus on multimedia applications, WPE WebKit is a great choice.
 
 WPE WebKit offers great possibilities for deployment on different platforms, thanks to its underlying design which allows for integration in a variety of hardware configurations. At a minimum, only EGL and OpenGL ES 2 support and basic GStreamer integration are required.
 
@@ -16,12 +16,12 @@ Some advantages of WPE WebKit:
 
 * The minimal set of dependencies needed to run WPE WebKit ensures that its footprint is small and it consumes less memory, which allows applications built with WPE WebKit to run on low-end devices.
 
-* WPE enables rich and fast 2D and 3D HTML-based user interfaces, integrating multimedia, 3D content, and many of the latest Web technologies, to run smoothly and efficiently on low-cost devices.
+* WPE enables rich and fast 2D and 3D HTML-based user interfaces, multimedia integration, 3D content, and many more of the latest Web technologies to run smoothly and efficiently on low-cost devices.
 
-* Displays multimedia content directly in HTML, with high-quality CSS 3D animations, WebGL, and fluid high quality HTML videos.
-Focused on graphics performance with multi-threading optimizations to improve CSS animation, scrolling, scaling, and rendering of canvas and video elements.
+* Displays multimedia content with high-quality CSS 3D animations, WebGL, and fluid high-quality HTML videos.
 
-* It provides a strong focus on multimedia applications and performance with WebRTC, MSE (MP4, WebM, VP9, Opus) and EME (ClearKey and other third-party DRM frameworks) supported and constantly improving.
+* Focused on graphics performance with multi-threading optimizations to improve CSS animation, scrolling, scaling, and rendering of canvas and video elements.
 
-* Unlicensed parts of YouTube TV and similar platforms are now enabled.
+* Provides a strong focus on multimedia applications and performance with WebRTC, MSE (MP4, WebM, VP9, Opus) and EME (ClearKey and other third-party DRM frameworks) supported and constantly improving.
 
+* Unlicensed parts of YouTube TV and similar platforms are supported.

--- a/about/architecture.md
+++ b/about/architecture.md
@@ -8,14 +8,7 @@ permalink: /about/architecture.html
 
 ### WPE
 
-The [WebKit](https://webkit.org) project is designed to provide programming
-interfaces to Web Browser developers. Depending on the platform and operating
-system the Browser application should run on, the developers should choose the
-right WebKit port suiting their needs. For instance, macOS application
-developers should rely on the WebKit mac ports. Linux desktop developers should
-build their application upon the [GTK port](https://webkitgtk.org).
-
-WPE is the official WebKit port for embedded platforms. WPE is uniquely designed
+WPE is the official [WebKit](https://webkit.org) port for embedded platforms. WPE is uniquely designed
 for embedded systems in that it doesn't depend on any user-interface toolkit
 such as the traditional Cocoa, GTK, etc toolkits.
 
@@ -27,7 +20,7 @@ such as the traditional Cocoa, GTK, etc toolkits.
 
 #### Web page rendering
 
-WPE is considered as an hybrid port, it defers the final web page delivery for
+WPE is considered a hybrid port because it defers the final web page delivery for
 display to a rendering backend. A traditional port would provide a widget for a
 given toolkit, but WPE opted for a different and more flexible approach.
 
@@ -47,12 +40,12 @@ specific embedded platforms that might have a graphics driver with special API
 requirements.
 
 WPE provides a rendering backend aiming to target the most common platforms and
-leveraging the existing graphics stack available in the
+leverage the existing graphics stack available in the
 [Freedesktop](https://freedesktop.org) umbrella eco-system.
 [WPEBackend-FDO](https://github.com/Igalia/WPEBackend-FDO) is the reference
-implementation of the base rendering backend design. WPEBackend-FDO provides API
+implementation of the base rendering backend design. WPEBackend-FDO provides an API
 for WPE applications that aims to ease the handling of rendering either
-on-screen using EGL or off-screen using SHM.
+on-screen using EGL, or off-screen using SHM.
 
 #### Input events handling
 
@@ -66,6 +59,6 @@ This design again adds flexibility to the overall WPE architecture, enabling
 applications to support new input devices without having to go through a UI
 toolkit first.
 
-Taking the example of the [Cog WPE browser](https://github.com/Igalia/cog), the
+In the example of the [Cog WPE browser](https://github.com/Igalia/cog), the
 application relies on Wayland protocols for user input to communicate events
-coming from the Wayland compositor up to WPE.
+coming from the Wayland compositor to WPE.

--- a/about/builds.md
+++ b/about/builds.md
@@ -6,6 +6,6 @@ data: { dateless: "true" }
 permalink: /about/builds.html
 ---
 
-While there are several [simple ways for developers to experiment and explore with WPE]({{'/about/exploring.html' | url}}) generally, for real, shipping projects or good performance testing embedded systems are typically custom builds.  To make this easier, there is also [meta-webkit](https://github.com/Igalia/meta-webkit) which provides build recipes  WebKit based runtimes and browsers for use with OpenEmbedded and/or Yocto.
+While there are several [simple ways for developers to experiment and explore with WPE]({{'/about/exploring.html' | url}}) generally, shipping projects or good performance-testing embedded systems are typically custom builds.  To make this easier, there is also [meta-webkit](https://github.com/Igalia/meta-webkit), which provides build recipes, WebKit based runtimes, and browsers for use with OpenEmbedded and/or Yocto.
 
 We also have some [performance tips](https://github.com/Igalia/meta-webkit/wiki/PerformanceTips) that might be helpful.

--- a/about/builds.md
+++ b/about/builds.md
@@ -6,6 +6,6 @@ data: { dateless: "true" }
 permalink: /about/builds.html
 ---
 
-While there are several [simple ways for developers to experiment and explore with WPE]({{'/about/exploring.html' | url}}) generally, shipping projects or good performance-testing embedded systems are typically custom builds.  To make this easier, there is also [meta-webkit](https://github.com/Igalia/meta-webkit), which provides build recipes, WebKit based runtimes, and browsers for use with OpenEmbedded and/or Yocto.
+While there are several [simple ways for developers to experiment with and explore WPE]({{'/about/exploring.html' | url}}), none are tuned for performance. Generally, shipping products for embedded systems are performance-tuned custom builds.  To make this easier, there is also [meta-webkit](https://github.com/Igalia/meta-webkit), which provides build recipes, WebKit based runtimes, and browsers for use with OpenEmbedded and/or Yocto.
 
 We also have some [performance tips](https://github.com/Igalia/meta-webkit/wiki/PerformanceTips) that might be helpful.

--- a/about/exploring.md
+++ b/about/exploring.md
@@ -6,32 +6,30 @@ data: { dateless: "true" }
 permalink: /about/exploring.html 
 --- 
 
-Long ago, it might have been reasonable to have imagine that maximum number of browsers that could be deployed in the world would be based on the maximum number of desktop computers.  However, embedded browsers are in everything these days - cars, signs, tablets, gaming systems, televisions and appliances - they're even in space.  The Web Platform is a frequently chosen foundational technology for <em>many reasons</em>, including:
+Long ago, it might have been reasonable to have imagine that maximum number of browsers that could be deployed in the world would be based on the maximum number of desktop computers.  However, embedded browsers are in everything these days: cars, signs, tablets, gaming systems, televisions and appliances.  They're even in space!  The Web Platform is a frequently chosen foundational technology for _many reasons_, including:
 
-* Because they are built on standards, they have great longevity 
+* Because Web Platform technologies are built on standards, they have great longevity 
 * Because these standards are open, embedded systems can incorporate them without licensing fees or other worries.  
 * Open standards with great longevity allows lots more things to benefit from the same investments
-* The number of people with the basic skills to build things with web technologies is massive. 
+* The number of people with the basic skills to build things with web technologies is massive 
 
-The fact that over the past few years _billions_ of new devices have come online, and the implications of this is still underdiscussed.  We believe developers need to be able explore and understand this space, and that lessons here are potentially helpful to the larger web ecosystem as well. However, this can be challenging because embedded browsers are a little different...
+The fact that over the past few years, _billions_ of new devices have come online, and the implications of this are still under-discussed.  We believe developers need to be able explore and understand this space, and that lessons learned here are potentially helpful to the larger web ecosystem as well. However, this can be challenging, because embedded browsers are a little different...
 
 ## Why embedded browsers are different
-For many of us, a browser is an application like the one you're probably using now.  You click an icon on your graphical operating system, navigate somewhere with a URL bar, search and so on.  You have bookmarks and tabs that you can drag around, and lots of other features.
+For many of us, a browser is an application like the one you're probably using now.  You click an icon on your graphical operating system, navigate somewhere with a URL bar, search, and so on.  You have bookmarks and tabs that you can drag around, and lots of other features.
 
-But, for most embedded systems this isn't the case at all.  For most embedded systems there isn't a common desktop OS - in fact, you create the OS.  Part of the reason for this is that by and large they are not general purpose computing devices, they have slightly different security concerns and they also run on often radically different sorts of hardware than your desktop, laptop or many mobile devices.
+For most embedded systems, this isn't the case at all.  For most embedded systems there isn't a common desktop OS&nbsp;— in fact, _you_ create the OS.  Part of the reason for this is that, by and large, they are not general-purpose computing devices.  They have slightly different security concerns, and they also run on often radically different sorts of hardware than your desktop, laptop or many mobile devices.
 
 So, what really _is_ an embedded browser?
 
 ### Browsers, engines and projects 
 
-The application that you are running to read this is, in all likelihood, a proper "browser".  This browser is built on one of 3 open source projects: WebKit, Chromium or Gecko.  These projects define something of an abstract browser - that is, they provide concrete implementations and an architecture through which something else (for example, a browser) can bind to the top layer in order to drive us from URL to URL, and to the bottom layer to fulfill things like actually painting on the screen, rendering graphics, receiving input from devices like keyboards, mice and pointing devices and connect to things like the speech subsystem.
+The application you are running to read this is, in all likelihood, a proper "browser".  This browser is built on one of three open source projects: WebKit, Chromium or Gecko.  Each of these projects defines an _engine_&nbsp;— that is, they provide an architecture through which something else (e.g., a browser) can bind to the top layer of the engine in order to drive us from URL to URL, and use the engine’s bottom layer to do things like actually put content on the screen, render graphics, receive input from devices like keyboards, mice and pointing devices, and connect to things like the text-to-speech subsystem.
 
 In terms of WebKit browsers, a "port" is something that provides things at those top and bottom layers.  The WebKit project has a few "official" ports that are 
-available from [webkit.org/downloads/](https://webkit.org/downloads/).  WPE is the official port for embedded systems, and it adds another layer to the architecture allowing for more easily swappable __backends_ (the graphics layers, windowing and so on) and various easier bindings for programmatic top level control in Linux based systems.  Cog is another project that makes it easier to launch and drive WPE views.
+available from [webkit.org/downloads/](https://webkit.org/downloads/).  WPE is the official port for embedded systems, and it adds another layer to the architecture allowing for more easily swappable _backends_ (the graphics layers, windowing and so on) and simpler bindings for programmatic top-level control in Linux based systems.  Cog is another project that makes it easier to launch and drive WPE views.
 
-In other words, WPE is designed to be _built_ and optimized for your embedded device in order to deliver the best performance.
-
-What all of this means is that there isn't really a single "WPE" that is as easy to provide as many browsers that you're probably familiar with that is entirely representative of what your experience will be like.
+In other words, WPE is designed to be _built_ and optimized for your embedded device in order to deliver the best performance.  What all of this means is that there isn't really a single "WPE" that’s as easy to provide as many browsers that you're probably familiar with.
 
 
 ### Easy ways to explore WPE
@@ -40,7 +38,7 @@ All of this said, we believe that enabling developers to explore the space is im
 
 * <span class="btn btn-primary text-light">[Install with Flatpak]({{'/about/flatpak.html' | url}})</span>: If you have support for Flatpak on your current hardware and operating system, and your graphics drivers are supported, there are various options to try WPE through Flatpak.  This can be a very easy way to let you explore WPE, check the features and specifications supported by WPE, or just want to experiment and learn more about what some of the differences with a full browser are.
 
-* <span class="btn btn-primary text-light">[Raspberry Pi OS with WPE image](https://wk-contrib.igalia.com/debian/images/wpe-raspbian.img.zip)</span>: Probably the most straight-forward way to learn a lot without a lot of experience in embedded is to try out our image that runs on Raspberry Pi OS.  Just download and flash the image onto an SD card, plug it in and go. Lots of developers have a Raspberry Pi sitting around somewhere and if you don't, you can one without a huge investment.  A Raspberry PI 3b, as of the time of this writing costs under $45, and can be connected to any display or keyboard.  The Raspberry Pi OS is a more or less full featured desktop OS, so it's easy to configure things like a WiFi connection, install a local server, setup SSH and so on.  The browser we've packed up with this distribution is _not_ especially optimized for the hardware, so you can get a pretty good feel of what running on really limited 32-bit hardware _can_ be like - and which sorts of performance related things we just owe to particular optimizations.
+* <span class="btn btn-primary text-light">[Raspberry Pi OS with WPE image](https://wk-contrib.igalia.com/debian/images/wpe-raspbian.img.zip)</span>: Probably the most straight-forward way to learn a lot without a lot of experience in embedded systems is to try out our image that runs on Raspberry Pi OS.  Just download and flash the image onto an SD card, plug it in and go.  Lots of developers have a Raspberry Pi sitting around somewhere, and if you don't, you can own one without a huge investment.  A Raspberry Pi 3b, as of the time of this writing, costs under $45, and can be connected to any display or keyboard.  The Raspberry Pi OS is a more or less full featured desktop OS, so it's easy to configure things like a WiFi connection, install a local server, setup SSH and so on.  The browser we've packed up with this distribution is _not_ especially optimized for the hardware, so you can get a pretty good feel of what running on really limited 32-bit hardware _can_ be like&nbsp;— and which sorts of performance related things we just owe to particular optimizations.
 
 
 

--- a/code.md
+++ b/code.md
@@ -28,7 +28,7 @@ For questions and hanging out you can find us here:
 
 ## Source
 
-There is, of course, the [WPE WebKit source](https://webkit.org/getting-the-code/) itself, but there are several supporting repositories as well:
+In addition to the [WPE WebKit source](https://webkit.org/getting-the-code/) itself, there are several supporting repositories as well:
 
 * [Cog](https://github.com/Igalia/cog): A small single “window” launcher for the WebKit WPE port, with no user interface, suitable to be used as a Web application container.
 * [WPEBackend-fdo](https://github.com/Igalia/WPEBackend-fdo): A FreeDesktop&period;org backend for WPE.

--- a/index.html
+++ b/index.html
@@ -295,12 +295,12 @@ lazy-youtube a > span {
       WPE powers <em>hundreds of millions</em> of embedded devices.
     </h3> 
 
-  <p class="lead mb-0">Embedded "browsers" are more than just a way that
+  <p class="lead mb-0">Embedded “browsers” are more than just a way that
     people can browse the Web as we commonly think about them:  They power
     increasingly many of the user interfaces that you encounter every day.
     From cable boxes to automobile and airplane infotainment systems, to
     kiosks, digital signage, smart appliances and video game
-    consoles&mdash;embedded browsers are everywhere.</p>
+    consoles&nbsp;&mdash; embedded browsers are everywhere.</p>
  
 
 </section>

--- a/release/schedule/index.md
+++ b/release/schedule/index.md
@@ -7,14 +7,14 @@ WPE WebKit follows a 6-month development cycle:
 
 - There are two feature releases are done every year, typically in March
   and September.
-- Within feature releases there may be any number of bug fix releases.
+- Within feature releases, there may be any number of bug-fix releases.
 - Development releases are the base for the feature releases that follow
   them. They do not follow a fixed schedule in the release cycle.
 
 
 WPE WebKit and [WebKitGTK](https://webkitgtk.org) share a fair amount of code.
 Therefore, both projects produce their feature releases simultaneously,
-and share the same release branches. For bug fix releases, the release
+and share the same release branches. For bug-fix releases, the release
 teams for both projects try to sync their version numbers as well as they
 can.
 
@@ -39,16 +39,16 @@ For stable releases the following is always true, as long as the `major`
 version number stays the same:
 
 - New `patch` releases are guaranteed to be backward-compatible *both*
-  at the API and ABI level.
+  at the <abbr title="Application Program Interface">API</abbr> and <abbr title="Application Binary Interface">ABI</abbr> level.
 - New `minor` releases may contain new features and backward-compatible
-  changes in the public API. In general the ABI will remain compatible as
+  changes in the public API. In general, the ABI will remain compatible as
   well, because we actively avoid breaking it unless strictly needed.
 
 
 ## Compatible Components
 
 The following table summarizes which *stable* releases of libwpe, WPE WebKit,
-WPEBackend-fdo, and Cog are compatible and tested with each other.
+WPEBackend-fdo, and Cog are compatible and tested with each other (updated March 2021).  Distributors and packagers are strongly advised to use the versions listed.
 
 | **WPE WebKit** | **libwpe**   | **WPEBackend-fdo** | **Cog**      |
 |:--------------:|:------------:|:------------------:|:------------:|
@@ -59,7 +59,6 @@ WPEBackend-fdo, and Cog are compatible and tested with each other.
 | 2.22.x         | 1.0.x        | 1.0.x              | 0.2.x        |
 | 2.20.x         | \< 1.0.0     | \< 1.0.0           | ≤ 0.1.x      |
 
-Distributors and packagers are strongly advised to use the versions above.
 
 **Notes:**
 


### PR DESCRIPTION
Did an editorial pass over all the public copy for clarity.  /about/architecture.html probably needs a review for technical accuracy; the rest of the pages were just touch-ups and should be fine.

----

Site preview: https://igalia.github.io/wpewebkit.org/doc-editorial/