### PR TITLE
Update compat table for the upcoming 2.32.x release

### DIFF
--- a/release/schedule/index.md
+++ b/release/schedule/index.md
@@ -52,6 +52,7 @@ WPEBackend-fdo, and Cog are compatible and tested with each other (updated March
 
 | **WPE WebKit** | **libwpe**   | **WPEBackend-fdo** | **Cog**      |
 |:--------------:|:------------:|:------------------:|:------------:|
+| 2.32.x         | 1.10.x, 1.8.x, 1.6.x | 1.10.x, 1.8.x | 0.8.x, 0.10.x |
 | 2.30.x         | 1.8.x, 1.6.x | 1.8.x              | 0.8.x, 0.6.x |
 | 2.28.x         | 1.6.x        | 1.6.x              | 0.8.x, 0.6.x |
 | 2.26.x         | 1.4.x        | 1.4.x              | 0.4.x        |


### PR DESCRIPTION
Add a row to the versions compatibility table for the 2.32.x release series, due by the end of March 2021.

----

Site preview: https://igalia.github.io/wpewebkit.org/aperezdc/update-compat-table/