### PR TITLE
Add microdata markup for posts

### DIFF
--- a/_includes/post.html
+++ b/_includes/post.html
@@ -1,13 +1,23 @@
 ---
 layout: page
 ---
+<div itemscope itemtype="http://schema.org/TechArticle">
+
+<meta itemprop="creativeWorkStatus" content="Published">
+<meta itemprop="isAccessibleForFree" content="True">
+<meta itemprop="publisher" content="WPE Team">
+<meta itemprop="author" content="WPE Team">
+<meta itemprop="url" content="{{ site.base_url }}{{ page.url | url }}">
+
 <section class="content-section bg-primary text-white small-section">
   <div class="container text-center">
     <div class="content-section-heading">
       {% if data.dateless != 'true' %}
-        <h3 class="text-secondary mb-0">{{ page.date | dateString }}</h3>
+        <h3 class="text-secondary mb-0"
+            itemprop="dateCreated">{{ page.date | dateString }}</h3>
+        <meta itemprop="datePublished" content="{{ page.date | dateString }}">
       {% endif %}
-      <h2>{{ title }}</h2>
+      <h2 itemprop="headline">{{ title }}</h2>
 	  {% if download %}
 	  <a class="btn btn-xl btn-secondary mt-3" href="{{ download }}">Download</a>
 	  {% elsif package and version %}
@@ -20,7 +30,7 @@ layout: page
 <section class="content-section bg-light small-section">
   <div class="container text-center">
     <div class="row">
-      <div class="col-lg-10 mx-auto lead text-left">
+      <div class="col-lg-10 mx-auto lead text-left" itemprop="articleBody">
 
         {{ content }}
 
@@ -29,3 +39,4 @@ layout: page
     </div>
   </div>
 </section>
+</div>


### PR DESCRIPTION
This is a first pass at adding schema.org Microdata markup to pages which use the `post` template. This adds inline metadata to the HTML markup which helps e.g. crawlers have a better view of content.

An introduction to Microdata can be found here: https://developer.mozilla.org/en-US/docs/Web/HTML/Microdata

----

Site preview: https://igalia.github.io/wpewebkit.org/aperezdc/microdata/