### PR TITLE
hw: List fdo/fdo as backend/shell for Panfrost

### DIFF
--- a/about/supported-hardware.md
+++ b/about/supported-hardware.md
@@ -53,7 +53,7 @@ Note that this list is not exhaustive. Reports of unlisted configurations are we
 
 | Device | GPU          | Driver | WPE Backend | Cog Shells |
 |--------|--------------|--------|-------------|------------|
-| RK3399 | Mali T860MP4 | panfrost (reverse-engineered) | | |
+| RK3399 | Mali T860MP4 | panfrost (reverse-engineered) | fdo | fdo |
 | RK3399 | Mali T860MP4 | Mali (Proprietary) | | |
 
 


### PR DESCRIPTION
While the drm Cog shell should work as well, I do not have any first hand report about it, so I would rather leave it out of the table for now.

----

Site preview: https://igalia.github.io/wpewebkit.org/aperezdc/hw-panfrost/