### PR TITLE
List WPEBackend-fdo 1.10 as compatible with WebKit 2.30

### DIFF
--- a/release/schedule/index.md
+++ b/release/schedule/index.md
@@ -53,7 +53,7 @@ WPEBackend-fdo, and Cog are compatible and tested with each other (updated March
 | **WPE WebKit** | **libwpe**   | **WPEBackend-fdo** | **Cog**      |
 |:--------------:|:------------:|:------------------:|:------------:|
 | 2.32.x         | 1.10.x, 1.8.x, 1.6.x | 1.10.x, 1.8.x | 0.8.x, 0.10.x |
-| 2.30.x         | 1.8.x, 1.6.x | 1.8.x              | 0.8.x, 0.6.x |
+| 2.30.x         | 1.8.x, 1.6.x | 1.10.x, 1.8.x      | 0.8.x, 0.6.x |
 | 2.28.x         | 1.6.x        | 1.6.x              | 0.8.x, 0.6.x |
 | 2.26.x         | 1.4.x        | 1.4.x              | 0.4.x        |
 | 2.24.x         | 1.2.x        | 1.2.x              | 0.3.x        |


### PR DESCRIPTION
As per https://github.com/Igalia/meta-webkit/pull/282#issuecomment-862487940

----

Site preview: https://igalia.github.io/wpewebkit.org/aperezdc/compat-table/