### PR TITLE
Update compat table for the upcoming 2.34.x release

### DIFF
--- a/release/schedule/index.md
+++ b/release/schedule/index.md
@@ -48,10 +48,13 @@ version number stays the same:
 ## Compatible Components
 
 The following table summarizes which *stable* releases of libwpe, WPE WebKit,
-WPEBackend-fdo, and Cog are compatible and tested with each other (updated March 2021).  Distributors and packagers are strongly advised to use the versions listed.
+WPEBackend-fdo, and Cog are compatible and tested with each other (updated
+October 2021). Distributors and packagers are strongly advised to use the
+versions listed below.
 
 | **WPE WebKit** | **libwpe**   | **WPEBackend-fdo** | **Cog**      |
 |:--------------:|:------------:|:------------------:|:------------:|
+| 2.34.x         | 1.12.x, 1.10.x, 1.8.x | 1.12.x, 1.10.x | 0.8.x, 0.10.x, 0.12.x |
 | 2.32.x         | 1.10.x, 1.8.x, 1.6.x | 1.10.x, 1.8.x | 0.8.x, 0.10.x |
 | 2.30.x         | 1.8.x, 1.6.x | 1.10.x, 1.8.x      | 0.8.x, 0.6.x |
 | 2.28.x         | 1.6.x        | 1.6.x              | 0.8.x, 0.6.x |


### PR DESCRIPTION
Add a row to the versions compatibility table for the 2.34.x release series, due October 2021.

----

Site preview: https://igalia.github.io/wpewebkit.org/aperezdc/compat-table/