### PR TITLE
hw: Fill in details for i.MX51 and i.MX53

### DIFF
--- a/about/supported-hardware.md
+++ b/about/supported-hardware.md
@@ -17,8 +17,8 @@ Note that this list is not exhaustive. Reports of unlisted configurations are we
 
 | Series  | GPU            | Driver      | WPE Backend | Cog Shells |
 |---------|----------------|-------------|-------------|------------|
-| i&period;MX 51 | Imageon Z460   |             |     | |
-| i&period;MX 53 | Imageon Z460   |             |     | |
+| i&period;MX 51 | Imageon Z460   | freedreno (reverse-engineered) | fdo | fdo, drm |
+| i&period;MX 53 | Imageon Z460   | freedreno (reverse-engineered) | fdo | fdo, drm |
 | i&period;MX 6  | Vivante GC2000 | etnaviv (reverse-engineered) | fdo | fdo, drm |
 | i&period;MX 6  | Vivante GC2000 | Vivante (Proprietary) | fdo | fdo |
 | i&period;MX 6  | Vivante GC2000 | Vivante (Proprietary) | rdk, `VIV_IMX6_EGL` | n/a |


### PR DESCRIPTION
Complete the entries in the hardware compatibility table for the i.MX51 and i.MX53 SoCs.

----

Site preview: https://igalia.github.io/wpewebkit.org/aperezdc/hwcompat/