### PR TITLE
CI: Do not error on empty PR bodies

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -45,15 +45,15 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            // Site preview link already added.
             const { data: pr } = await github.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: context.issue.number,
             });
 
+            // Site preview link already added.
             const marker = '\n\n----\n\nSite preview: ';
-            if (pr.body.indexOf(marker) != -1)
+            if (pr.body && pr.body.indexOf(marker) != -1)
               return;
 
             await github.pulls.update({


### PR DESCRIPTION
Check pr.body before using it; when the body of the PR description is empty, GitHub sets the attribute to null.

----

Site preview: https://igalia.github.io/wpewebkit.org/aperezdc/ci-no-body-in-pr/