### PR TITLE
Cleanup blog post Markdown sources

### DIFF
--- a/_posts/2022-04-21-blog-happy-birthday-wpe.md
+++ b/_posts/2022-04-21-blog-happy-birthday-wpe.md
@@ -6,7 +6,7 @@ author: nzimmermann
 permalink: /blog/01-happy-birthday-wpe.html
 ---
 
-Welcome to the new *Blog* section on [wpewebkit.org](https://wpewebkit.org)!
+Welcome to the new *Blog* section on [wpewebkit.org]({{ '/' | url }})!
 
 Today is a special day for **Igalia**, especially for those colleagues that work on WebKit:
 Five years ago, on the **21st of April 2017**, the WPE port was announced by our colleague
@@ -24,12 +24,12 @@ worldwide today.
 To get everyone on the same page, let's start by reiterating what WPE is: **a WebKit port optimized for embedded devices**.
 It allows you to embed a full-fledged **Web browser engine** that supports a large set of modern Web technologies into your product.
 WPE itself is *not* a Web browser such as Safari, Chrome or Firefox but contains the underlying building blocks to load, parse and
-render websites. To learn more about the distinction between a Web browser and a Web browser engine read [our explainer](/about/exploring.html).
+render websites. To learn more about the distinction between a Web browser and a Web browser engine read [our explainer]({{ '/about/exploring.html' | url }}).
 
 You might ask yourself, what does *"optimized for embedded devices"* mean in practice? Unlike most other WebKit ports, WPE does not
 rely on a specific user-interface toolkit, such as [Qt](https://qt.io), [GTK](https://gtk.org), [Cocoa](https://en.wikipedia.org/wiki/Cocoa_(API)),
 etc., nor does it offer any integration with these kinds of toolkits. WPE WebKit is light-weight, integrates well with a
-[variety of hardware configurations](/about/supported-hardware.html), and only requires a minimum set of APIs on your side:
+[variety of hardware configurations]({{ '/about/supported-hardware.html' | url }}), and only requires a minimum set of APIs on your side:
 **[EGL](https://en.wikipedia.org/wiki/EGL_(API))** and **[OpenGL ES 2](https://en.wikipedia.org/wiki/OpenGL_ES)**.
 
 ## The early days 2014 - 2017
@@ -48,7 +48,7 @@ Therefore Igalia decided to aim for an even more flexible design, where *Wayland
 Our fellow Igalian [Miguel Gomez](https://www.igalia.com/team/magomez) reported in his [late 2016 blog post](https://blogs.igalia.com/magomez/2016/12/19/wpe-web-platform-for-embedded)
 about this change, and the renaming of the port: **WPE** appears for the first time in public.
 
-The project's removal of the Wayland dependency and the subsequent reorganization lead to the [architecture we have today](/about/architecture.html),
+The project's removal of the Wayland dependency and the subsequent reorganization lead to the [architecture we have today]({{ '/about/architecture.html' | url }}),
 consisting of not only the WPE port itself but a whole ecosystem of projects such as [libwpe](https://github.com/WebPlatformForEmbedded/libwpe),
 [WPEBackend-fdo](https://github.com/Igalia/WPEBackend-FDO), [WPEBackend-rdk](https://github.com/WebPlatformForEmbedded/WPEBackend-rdk), etc.,
 that together form the **WPE** project.
@@ -70,7 +70,7 @@ and ecosystem around it healthier too.
 However, none of this would be possible without the commitment of many [Igalians](https://www.igalia.com/team) pushing the project forward every day for the past **8 years**.
 A new **People Behind WPE** series will be launched soon: over the following months, the Igalians involved with WPE will introduce themselves, their area of
 expertise, and talk about a specific WPE related technical topic. You'll get to know the people behind the product and a first-class technical overview
-of individual parts of the WPE architecture! We plan to release a new article every 3-4 weeks, so be sure to visit [wpewebkit.org/blog](https://wpewebkit.org/blog)
+of individual parts of the WPE architecture! We plan to release a new article every 3-4 weeks, so be sure to visit [wpewebkit.org/blog]({{ '/blog/' | url }})
 again soon and enjoy the upcoming **People Behind WPE** series.
 
 Feel free to spread the word and make noise about WPE. Stay healthy, stay tuned!

--- a/_posts/2022-07-01-blog-overview-of-wpe.md
+++ b/_posts/2022-07-01-blog-overview-of-wpe.md
@@ -6,8 +6,8 @@ author: csaavedra
 permalink: /blog/02-overview-of-wpe.html
 ---
 
-In <a href="/blog/01-happy-birthday-wpe.html">the
-previous post in this series</a>, we explained that WPE is a WebKit
+In [the previous post in this series]({{ '/blog/01-happy-birthday-wpe.html' | url }}),
+we explained that WPE is a WebKit
 port optimized for embedded devices. In this post, we'll dive into a
 more technical overview of the different components of WPE, WebKit,
 and how they all fit together. If you're still wondering what a web
@@ -56,10 +56,15 @@ difficult for any vendor trying to reuse WebKit in a new platform to
 support new hardware and implement a browser, right? All that you need
 to do is:
 
-- Implement backends that integrate with your hardware platform: for multimedia, IO, OS support, networking, graphics, etc.
+- Implement backends that integrate with your hardware platform: for
+  multimedia, IO, OS support, networking, graphics, etc.
 - Write an API that you can use to plug the engine into your browser.
-- Maintain the changes needed off-tree, that is, outside the source code tree of WebKit.
-- Keep your implementation up-to-date with the many changes that happen in the WebKit codebase on a daily basis, so that you can update WebKit regularly and take advantage of the many bug fixes, improvements, and new features that land on WebKit continuously.
+- Maintain the changes needed off-tree, that is, outside the source code tree
+  of WebKit.
+- Keep your implementation up-to-date with the many changes that happen in the
+  WebKit codebase on a daily basis, so that you can update WebKit regularly
+  and take advantage of the many bug fixes, improvements, and new features
+  that land on WebKit continuously.
 
 Does that sound easy? No, it's not easy at all! In fact,
 implementation of ports in this fashion is strongly discouraged and
@@ -91,18 +96,51 @@ improvements that land on the WebKit repository on a daily basis.
 
 ## How does WPE integrate with WebKit?
 
-![A diagram of the WPE WebKit architecture](/assets/wpe-architecture-diagram.png)
+<img style="display: block; margin: 1em auto;"
+	alt="A diagram of the WPE WebKit architecture"
+	src="{{ '/assets/wpe-architecture-diagram.png' | url }}">
 
 The WPE port has several components. Some are in-tree (that is, are a
 part of WebKit itself), while others are out-of-tree. Let's examine
 those components and how they relate to each other, from top to
 bottom:
 
-- The <a href="https://github.com/Igalia/cog#cog">cog library</a>. While not an integral part of WPE, libcog is a shell library that simplifies the task of writing a WPE browser from the scratch, by providing common functionality and helper APIs. This component also includes the cog browser, a simple WPE browser built on top of libcog that can be used as a reference or a starting point for the development of a new browser for a specific use case.
-- The <a href="https://people.igalia.com/aperez/Documentation/wpe-webkit-1.1/">WebKit WPE API</a>: the entry point for browser developers to the WebKit engine, provides a comprehensive GObject/C API. The cog library uses this API extensively and we recommend relying on it, but for more specific needs and more fine-tuning of the engine, working directly with the WebKit API can be often necessary. The API is stable and easy to use, especially, and for those familiar with the GTK/GNOME platform.
-- WPE's WebCore implementation: This part, internal to WebKit, implements an abstraction of the graphics and input layers of WebKit. This implementation relies on the libwpe library to provide the functionality required in an abstract way. Thanks to the architecture of WPE, implementors don't need to bother with the complexities of WebCore and WebKit internals.
-- The <a href="https://github.com/WebPlatformForEmbedded/libwpe">libwpe</a> library. This is an out-of-tree library that provides the API required by the WPE port in a generic way to implement the graphical and input backends. Specific functionality for a concrete platform is not provided, but the library relies on the existence of a backend implementation, as is described next.
-- Finally, a WPE backend implementation. This is where all the platform-specific code lives. Backends are loadable modules that can be chosen depending on the underlying hardware. These should provide access to graphics and input depending on the specific architecture, platform, and operating system requirements. As a reference, <a href="https://github.com/Igalia/WPEBackend-fdo">WPEBackend-fdo</a> is a freedesktop.org-based backend, which uses Wayland and freekdesktop.org technologies, and is <a href="/about/supported-hardware.html">supported for several architectures</a>, including NXP and Broadcom chipsets, like the Raspberry PI, and also regular PC architectures, easing testing and development.
+- The <a href="https://github.com/Igalia/cog#cog">Cog library</a>.
+  While not an integral part of WPE, libcog is a shell library that simplifies
+  the task of writing a WPE browser from the scratch, by providing common
+  functionality and helper APIs. This component also includes the cog browser,
+  a simple WPE browser built on top of libcog that can be used as a reference
+  or a starting point for the development of a new browser for a specific use
+  case.
+- The <a href="https://people.igalia.com/aperez/Documentation/wpe-webkit-1.1/">WPE WebKit API</a>:
+  the entry point for browser developers to the WebKit engine, provides a
+  comprehensive GObject/C API. The cog library uses this API extensively and
+  we recommend relying on it, but for more specific needs and more fine-tuning
+  of the engine, working directly with the WebKit API can be often necessary.
+  The API is stable and easy to use, especially, and for those familiar with
+  the GTK/GNOME platform.
+- WPE's WebCore implementation: This part, internal to WebKit, implements
+  an abstraction of the graphics and input layers of WebKit. This
+  implementation relies on the libwpe library to provide the functionality
+  required in an abstract way. Thanks to the architecture of WPE, implementors
+  don't need to bother with the complexities of WebCore and WebKit internals.
+- The <a href="https://github.com/WebPlatformForEmbedded/libwpe">libwpe</a>
+  library. This is an out-of-tree library that provides the API required by
+  the WPE port in a generic way to implement the graphical and input backends.
+  Specific functionality for a concrete platform is not provided, but the
+  library relies on the existence of a backend implementation, as is described
+  next.
+- Finally, a WPE backend implementation. This is where all the
+  platform-specific code lives. Backends are loadable modules that can be
+  chosen depending on the underlying hardware. These should provide access to
+  graphics and input depending on the specific architecture, platform, and
+  operating system requirements. As a reference, <a
+  href="https://github.com/Igalia/WPEBackend-fdo">WPEBackend-fdo</a> is a
+  freedesktop.org-based backend, which uses Wayland and freekdesktop.org
+  technologies, and is <a href="{{ '/about/supported-hardware.html' | url }}">
+  supported for several architectures</a>, including NXP and Broadcom chipsets, like the
+  Raspberry Pi, and also regular PC architectures, easing testing and
+  development.
 
 An implementor interested in building a browser in a new architecture
 only needs to focus on the development of the last component -- a WPE
@@ -110,28 +148,24 @@ backend. Having a backend, starting the development of a
 WebKit-powered browser is already much easier than it ever was!
 
 For a more detailed description of the architecture of WPE and WebKit,
-check this article on <a
-href="/about/architecture.html">the architecture
-of WPE</a>.
+check this article on [the architecture of WPE]({{ '/about/architecture.html' | url }}).
 
 ## OK, sounds interesting, how do I get my hands dirty?
 
 If you have made it this far, you should give WPE a try!
 
-We have listed several on the <a
-href="/about/exploring.html">exploring WPE</a>
+We have listed several on the [exploring WPE]({{ '/about/exploring.html' | url }})
 page. From there, you will see that depending on how interested you
 are in the project, your background, and what you'd like to do with
 it, there are different ways!
 
 It can be as easy as installing WPE directly from the most popular
 Linux distributions or downloading and flashing prebuilt images for
-the Raspberry Pi. There are easy and flexible options like <a
-href="/about/flatpak.html">flatpak</a>, <a
-href="/about/balena-wpe.html">balena</a> which
-you can dig into to learn more.  If you want to build WPE yourself,
-you can use <a
-href="https://github.com/Igalia/meta-webkit/wiki/WPE">yocto</a> and if
-you'd like to contribute - that's very welcome!
+the Raspberry Pi. There are easy and flexible options like
+[Flatpak]({{ '/about/flatpak.html' | url }}) or
+[Balena]({{ '/about/balena-wpe.html' | url }}), which
+you can dig into to learn more. If you want to build WPE yourself,
+you can use [Yocto](https://github.com/Igalia/meta-webkit/wiki/WPE) and if
+you'd like to contribute&mdash;that's very welcome!
 
 Happy hacking!

--- a/_posts/2022-07-15-blog-wpe-graphics-architecture.md
+++ b/_posts/2022-07-15-blog-wpe-graphics-architecture.md
@@ -6,22 +6,26 @@ author: magomez
 permalink: /blog/03-wpe-graphics-architecture.html
 ---
 
-Following <a href="/blog/02-overview-of-wpe.html">the previous post in the series about <a href="https://wpewebkit.org/">WPE</a> where we talked about the <a href="https://wpewebkit.org/">WPE</a> components, this post will explain briefly the <a href="https://wpewebkit.org/">WPE</a> graphics architecture, and how the engine is able to render HTML content into the display. If you haven't read the previous entries in this blog post series about <a href="https://wpewebkit.org/">WPE</a>, we recommend you to start with the <a href="/blog/01-happy-birthday-wpe.html">first post in the series</a> for an introduction, and then come back to this.
+Following <a href="{{ '/blog/02-overview-of-wpe.html' | url }}">the previous post in the series</a> about <a href="{{ '/' | url }}">WPE</a> where we talked about the WPE components, this post will explain briefly the WPE graphics architecture, and how the engine is able to render HTML content into the display. If you haven't read the previous entries in this blog post series about WPE, we recommend you to start with the <a href="{{ '/blog/01-happy-birthday-wpe.html' | url}}">first post in the series</a> for an introduction, and then come back to this.
 
 
 ## DOM + CSS = RenderTree
 
-As the document is parsed, it will begin building the DOM tree and load-blocking CSS resources.  At some point, possibly before the entire DOM tree is built, it's time to draw things on the screen. The first step to render the content of a page is to perform what's called the *attachment*, which is merging the DOM tree with the CSS rules, in order to create the RenderTree. This RenderTree is a collection of <a href="https://github.com/WebKit/WebKit/blob/webkitgtk/2.36/Source/WebCore/rendering/RenderObject.h">RenderObjects</a>, structured into a tree, and each of these <a href="https://github.com/WebKit/WebKit/blob/webkitgtk/2.36/Source/WebCore/rendering/RenderObject.h">RenderObjects</a> represent the elements in the DOM tree that have visual output. <a href="https://github.com/WebKit/WebKit/blob/webkitgtk/2.36/Source/WebCore/rendering/RenderObject.h">RenderObjects</a> have the capability to render the associated DOM tree node into a surface by using the <a href="https://github.com/WebKit/WebKit/blob/webkitgtk/2.36/Source/WebCore/platform/graphics/GraphicsContext.h">GraphicsContext</a> class (in the case of <a href="https://wpewebkit.org/">WPE</a>, this <a href="https://github.com/WebKit/WebKit/blob/webkitgtk/2.36/Source/WebCore/platform/graphics/GraphicsContext.h">GraphicsContext</a> uses <a href="https://www.cairographics.org/">cairo</a> to perform the rendering).
+As the document is parsed, it will begin building the DOM tree and load-blocking CSS resources.  At some point, possibly before the entire DOM tree is built, it's time to draw things on the screen. The first step to render the content of a page is to perform what's called the *attachment*, which is merging the DOM tree with the CSS rules, in order to create the RenderTree. This RenderTree is a collection of <a href="https://github.com/WebKit/WebKit/blob/webkitgtk/2.36/Source/WebCore/rendering/RenderObject.h">RenderObjects</a>, structured into a tree, and each of these <a href="https://github.com/WebKit/WebKit/blob/webkitgtk/2.36/Source/WebCore/rendering/RenderObject.h">RenderObjects</a> represent the elements in the DOM tree that have visual output. <a href="https://github.com/WebKit/WebKit/blob/webkitgtk/2.36/Source/WebCore/rendering/RenderObject.h">RenderObjects</a> have the capability to render the associated DOM tree node into a surface by using the <a href="https://github.com/WebKit/WebKit/blob/webkitgtk/2.36/Source/WebCore/platform/graphics/GraphicsContext.h">GraphicsContext</a> class (in the case of WPE, this <a href="https://github.com/WebKit/WebKit/blob/webkitgtk/2.36/Source/WebCore/platform/graphics/GraphicsContext.h">GraphicsContext</a> uses <a href="https://www.cairographics.org/">Cairo</a> to perform the rendering).
 
 Once the RenderTree is created, the layout is performed, ensuring that each of the <a href="https://github.com/WebKit/WebKit/blob/webkitgtk/2.36/Source/WebCore/rendering/RenderObject.h">RenderObjects</a> have their proper size and position set.
 
-![Going from source content to displayed content](/assets/graphics-attachment.png)
+<img style="display: block; margin: 1em auto;"
+	alt="Going from source content to displayed content"
+	src="{{ '/assets/graphics-attachment.png' | url }}">
 
 It would be possible to render the content of the web page just traversing this RenderTree and painting each of the <a href="https://github.com/WebKit/WebKit/blob/webkitgtk/2.36/Source/WebCore/rendering/RenderObject.h">RenderObjects</a>, but there would be problems when rendering elements that overlap each other, because the order of the elements in the RenderTree doesn't necessarily match the order in which they must be painted in order to get the appropriate result. For example, an element with a big `z-index` value should be painted last, no matter its position in the RenderTree.
 
 This is an example of how some HTML content is translated into the RenderTree (there are some <a href="https://github.com/WebKit/WebKit/blob/webkitgtk/2.36/Source/WebCore/rendering/RenderObject.h">RenderObjects</a> missing here that are not relevant for the explanation).
 
-![RenderTree generated from example HTML](/assets/graphics-rendertree.png)
+<img style="display: block; margin: 1em auto;"
+	alt="RenderTree generated from example HTML"
+	src="{{ '/assets/graphics-rendertree.png' | url }}">
 
 ## RenderLayers
 
@@ -33,7 +37,9 @@ There are several conditions that can decide whether a <a href="https://github.c
 
 Continuing with the example, these are <a href="https://github.com/WebKit/WebKit/blob/webkitgtk/2.36/Source/WebCore/rendering/RenderLayer.h">RenderLayers</a> that we would get for that HTML code:
 
-![RenderLayer tree generated from example HTML](/assets/graphics-renderlayertree.png)
+<img style="display: block; margin: 1em auto;"
+	alt="RenderLayer tree generated from example HTML"
+	src="{{ '/assets/graphics-renderlayertree.png' | url }}">
 
 We can see that there are four <a href="https://github.com/WebKit/WebKit/blob/webkitgtk/2.36/Source/WebCore/rendering/RenderLayer.h">RenderLayers</a>:
 
@@ -42,7 +48,7 @@ We can see that there are four <a href="https://github.com/WebKit/WebKit/blob/we
 - One corresponding to the RenderVideo element, because video elements always get their own <a href="https://github.com/WebKit/WebKit/blob/webkitgtk/2.36/Source/WebCore/rendering/RenderLayer.h">RenderLayer</a>.
 - One corresponding to the transformed RenderBlock.
 
-<a href="https://github.com/WebKit/WebKit/blob/webkitgtk/2.36/Source/WebCore/rendering/RenderLayer.h">RenderLayers</a> have a paint method that is able to paint all the <a href="https://github.com/WebKit/WebKit/blob/webkitgtk/2.36/Source/WebCore/rendering/RenderObject.h">RenderObjects</a> associated to the layer into a <a href="https://github.com/WebKit/WebKit/blob/webkitgtk/2.36/Source/WebCore/platform/graphics/GraphicsContext.h">GraphicsContext</a> (as mentioned, <a href="https://wpewebkit.org/">WPE</a> uses <a href="https://www.cairographics.org/">cairo</a> for this). As in the previous case, it's possible to paint the content of the page at this point just by traversing the <a href="https://github.com/WebKit/WebKit/blob/webkitgtk/2.36/Source/WebCore/rendering/RenderLayer.h">RenderLayer</a> tree and requesting the <a href="https://github.com/WebKit/WebKit/blob/webkitgtk/2.36/Source/WebCore/rendering/RenderLayer.h">RenderLayers</a> to paint their content, but in this case the result will be the correct one. Actually this is what <a href="https://webkitgtk.org/">WebKitGTK</a> does when it's run with accelerated compositing disabled.
+<a href="https://github.com/WebKit/WebKit/blob/webkitgtk/2.36/Source/WebCore/rendering/RenderLayer.h">RenderLayers</a> have a paint method that is able to paint all the <a href="https://github.com/WebKit/WebKit/blob/webkitgtk/2.36/Source/WebCore/rendering/RenderObject.h">RenderObjects</a> associated to the layer into a <a href="https://github.com/WebKit/WebKit/blob/webkitgtk/2.36/Source/WebCore/platform/graphics/GraphicsContext.h">GraphicsContext</a> (as mentioned, WPE uses <a href="https://www.cairographics.org/">Cairo</a> for this). As in the previous case, it's possible to paint the content of the page at this point just by traversing the <a href="https://github.com/WebKit/WebKit/blob/webkitgtk/2.36/Source/WebCore/rendering/RenderLayer.h">RenderLayer</a> tree and requesting the <a href="https://github.com/WebKit/WebKit/blob/webkitgtk/2.36/Source/WebCore/rendering/RenderLayer.h">RenderLayers</a> to paint their content, but in this case the result will be the correct one. Actually this is what <a href="https://webkitgtk.org/">WebKitGTK</a> does when it's run with accelerated compositing disabled.
 
 ## Layer composition
 
@@ -58,7 +64,9 @@ Once we have the <a href="https://github.com/WebKit/WebKit/blob/webkitgtk/2.36/S
 
 This is how the example code would be translated into <a href="https://github.com/WebKit/WebKit/blob/webkitgtk/2.36/Source/WebCore/platform/graphics/GraphicsLayer.h">GraphicsLayers</a>.
 
-![GraphicsLayer tree generated from example HTML](/assets/graphics-graphicslayertree.png)
+<img style="display: block; margin: 1em auto;"
+	alt="GraphicsLayer tree generated from example HTML"
+	src="{{ '/assets/graphics-graphicslayertree.png' | url }}">
 
 We can see that we have now three <a href="https://github.com/WebKit/WebKit/blob/webkitgtk/2.36/Source/WebCore/platform/graphics/GraphicsLayer.h">GraphicsLayers</a>:
 
@@ -72,7 +80,7 @@ So now we have successfully separated the content that is changing and needs to 
 
 ## Accelerated compositing and threaded accelerated compositing
 
-There's something else that be done in order to increase the rendering performance, and it's using the GPU to perform the composition. The GPU is highly optimized to perform operations like the buffer composition that we need to do, as well as handle 3D transforms, blending, etc. We just need to upload the buffers into textures and let the GPU handle the required operations. <a href="https://wpewebkit.org/">WPE</a> does this though the usage of the <a href="https://www.khronos.org/egl">EGL</a> and <a href="https://www.khronos.org/opengles/">GLES2</a> graphics APIs. In order to perform the composition, <a href="https://www.khronos.org/egl">EGL</a> is used to create a <a href="https://www.khronos.org/opengles/">GLES2</a> EGLContext. Using that context, the intermediate buffers are uploaded to textures, and then those textures are positioned and composited according to their appropriate positions. This leverages the GPU for the composition work, leaving the CPU free to perform other tasks.
+There's something else that be done in order to increase the rendering performance, and it's using the GPU to perform the composition. The GPU is highly optimized to perform operations like the buffer composition that we need to do, as well as handle 3D transforms, blending, etc. We just need to upload the buffers into textures and let the GPU handle the required operations. WPE does this though the usage of the <a href="https://www.khronos.org/egl">EGL</a> and <a href="https://www.khronos.org/opengles/">GLES2</a> graphics APIs. In order to perform the composition, <a href="https://www.khronos.org/egl">EGL</a> is used to create a <a href="https://www.khronos.org/opengles/">GLES2</a> `EGLContext`. Using that context, the intermediate buffers are uploaded to textures, and then those textures are positioned and composited according to their appropriate positions. This leverages the GPU for the composition work, leaving the CPU free to perform other tasks.
 
 This is why this step is called accelerated compositing.
 
@@ -80,7 +88,7 @@ But there's more.
 
 Until this point, all the steps that are needed to render the content of the page are performed in the main <a href="https://en.wikipedia.org/wiki/Thread_(computing)">thread</a>. This means that while the main thread is rendering and compositing, it's not able to perform other tasks, like run JS code.
 
-<a href="https://wpewebkit.org/">WPE</a> improves this by using a parallel thread whose only mission is to perform the composition. You can think of it as a thread that runs a loop that composites the incoming buffers using the GPU when there's content to render. This is what we call *threaded accelerated compositing*.
+WPE improves this by using a parallel thread whose only mission is to perform the composition. You can think of it as a thread that runs a loop that composites the incoming buffers using the GPU when there's content to render. This is what we call *threaded accelerated compositing*.
 
 This is specially useful when there's a video or an animation running on the page:
 
@@ -88,38 +96,38 @@ This is specially useful when there's a video or an animation running on the pag
 
 - If there's an animation, in the non-threaded case, for each frame of the animation the main thread would need to calculate the animation step and then perform the composition of the animated element with the rest of the page content. In the threaded case, the animation is passed to the compositor thread, and the animation steps are calculated on that thread, triggering a composition when needed. The main thread doesn't need to to anything besides starting the animation.
 
-It would take another post to explain in detail how the threaded accelerated composition is implemented on <a href="https://wpewebkit.org/">WPE</a>, but if you're curious about it, know that <a href="https://wpewebkit.org/">WPE</a> uses an specialization of the <a href="https://github.com/WebKit/WebKit/blob/webkitgtk/2.36/Source/WebCore/platform/graphics/GraphicsLayer.h">GraphicsLayer</a> called <a href="https://github.com/WebKit/WebKit/blob/webkitgtk/2.36/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h">CoordinatedGraphicsLayer</a> in order to implement this. You can use that as an starting point.
+It would take another post to explain in detail how the threaded accelerated composition is implemented on WPE, but if you're curious about it, know that WPE uses an specialization of the <a href="https://github.com/WebKit/WebKit/blob/webkitgtk/2.36/Source/WebCore/platform/graphics/GraphicsLayer.h">GraphicsLayer</a> called <a href="https://github.com/WebKit/WebKit/blob/webkitgtk/2.36/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h">CoordinatedGraphicsLayer</a> in order to implement this. You can use that as an starting point.
 
-So this is the whole process that's performed in <a href="https://wpewebkit.org/">WPE</a> in order to display the content of a page. We hope it's useful!!
+So this is the whole process that's performed in WPE in order to display the content of a page. We hope it's useful!
 
 ## Future
 
-At <a href="https://www.igalia.com/">Igalia</a> we're constantly evolving and improving <a href="https://wpewebkit.org/">WPE</a>, and have ongoing efforts to improve the graphics architecture as well. Besides small optimizations and refactors here and there, the most important goals that we have are:
+At <a href="https://www.igalia.com/">Igalia</a> we're constantly evolving and improving WPE, and have ongoing efforts to improve the graphics architecture as well. Besides small optimizations and refactors here and there, the most important goals that we have are:
 
-- **Add a GPU process.** Currently the <a href="https://www.khronos.org/egl">EGL</a> and <a href="https://www.khronos.org/opengles/">GLES2</a> operations are performed in the web process. As there can be several web processes running when several pages are open, this means the browser can be using a lot of EGLContexts in total, which is a waste of memory. Also, all these processes could potentially be affected by errors, leaks, etc., in the code that handles the GPU operations. The idea is to centralize all the GPU operations into a single process, the GPU one, so all the web processes will issue paint requests to the GPU process instead of painting their content themselves. This will reduce the memory usage and improve the software's robustness.
+- **Add a GPU process.** Currently the <a href="https://www.khronos.org/egl">EGL</a> and <a href="https://www.khronos.org/opengles/">GLES2</a> operations are performed in the web process. As there can be several web processes running when several pages are open, this means the browser can be using a lot of EGL contexts in total, which is a waste of memory. Also, all these processes could potentially be affected by errors, leaks, etc., in the code that handles the GPU operations. The idea is to centralize all the GPU operations into a single process, the GPU one, so all the web processes will issue paint requests to the GPU process instead of painting their content themselves. This will reduce the memory usage and improve the software's robustness.
 
 - **Remove CPU rasterization and paint all the content with <a href="https://www.khronos.org/opengles/">GLES2</a>.** Using the CPU to paint the layer contents with <a href="https://www.cairographics.org/">cairo</a> is expensive, especially in platforms with slow CPUs, as embedded devices sometimes do. Our goal here is to completely remove the <a href="https://www.cairographics.org/">cairo</a> rasterization and use <a href="https://www.khronos.org/opengles/">GLES2</a> calls to render the 2D primitives. This will greatly improve the rendering performance.
 
-- **Use <a href="https://github.com/google/angle">ANGLE</a> to perform <a href="https://www.khronos.org/webgl/">WebGL</a> operations.** <a href="https://wpewebkit.org/">WPE</a> currently implements the <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/">WebGL 1.0 specification</a> through direct calls to <a href="https://www.khronos.org/opengles/">GLES2</a> methods. We are changing this in order to perform the operations using <a href="https://github.com/google/angle">ANGLE</a>, which will allow <a href="https://wpewebkit.org/">WPE</a> to support the <a href="https://www.khronos.org/registry/webgl/specs/latest/2.0/">WebGL 2.0 specification</a> as well.
+- **Use <a href="https://github.com/google/angle">ANGLE</a> to perform <a href="https://www.khronos.org/webgl/">WebGL</a> operations.** WPE currently implements the <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/">WebGL 1.0 specification</a> through direct calls to <a href="https://www.khronos.org/opengles/">GLES2</a> methods. We are changing this in order to perform the operations using <a href="https://github.com/google/angle">ANGLE</a>, which will allow WPE to support the <a href="https://www.khronos.org/registry/webgl/specs/latest/2.0/">WebGL 2.0 specification</a> as well.
 
 ## But what about the backends?
 
-In <a href="/blog/02-overview-of-wpe.html">the previous post</a> there was a mention of backends that are used to integrate with the underlying platform. How is this relevant to the graphics architecture?
+In <a href="{{ '/blog/02-overview-of-wpe.html' | url }}">the previous post</a> there was a mention of backends that are used to integrate with the underlying platform. How is this relevant to the graphics architecture?
 
 Backends have several missions when it comes to communicate with the platform, but regarding graphics, they have two functions to achieve:
 
-- Provide a platform dependent surface that <a href="https://wpewebkit.org/">WPE</a> will render to. This can be a normal buffer, a <a href="https://wayland.freedesktop.org/">Wayland</a> buffer, a native window, or whatever, as long as the system <a href="https://www.khronos.org/egl">EGL</a> implementation allows creating an EGLContext to render to it.
+- Provide a platform dependent surface that WPE will render to. This can be a normal buffer, a <a href="https://wayland.freedesktop.org/">Wayland</a> buffer, a native window, or whatever, as long as the system <a href="https://www.khronos.org/egl">EGL</a> implementation allows creating an `EGLContext` to render to it.
 
-- Process <a href="https://wpewebkit.org/">WPE</a> indications that a new frame has been rendered, performing whatever tasks are necessary to take that frame to the display. Also notify <a href="https://wpewebkit.org/">WPE</a> when that frame was been displayed.
+- Process WPE indications that a new frame has been rendered, performing whatever tasks are necessary to take that frame to the display. Also notify WPE when that frame was been displayed.
 
-The most common example of this is a <a href="https://wayland.freedesktop.org/">Wayland</a> backend, which provides a <a href="https://wayland.freedesktop.org/">Wayland</a> buffer to <a href="https://wpewebkit.org/">WPE</a> for rendering. When <a href="https://wpewebkit.org/">WPE</a> has finished rendering the content, it notifies the backend, which sends the buffer to the <a href="https://wayland.freedesktop.org/">Wayland</a> compositor, and notifies back to <a href="https://wpewebkit.org/">WPE</a> when the frame has been displayed.
+The most common example of this is a <a href="https://wayland.freedesktop.org/">Wayland</a> backend, which provides a buffer to WPE for rendering. When WPE has finished rendering the content, it notifies the backend, which sends the buffer to the Wayland compositor, and notifies back to WPE when the frame has been displayed.
 
-So, whatever platform you want to run <a href="https://wpewebkit.org/">WPE</a> on, you need to have a backend providing at least these capabilities.
+So, whatever platform you want to run WPE on, you need to have a backend providing at least these capabilities.
 
 ## Final thoughts
 
-This was a brief overview of how <a ref="https://wpewebkit.org/">WPE</a> rendering works, and also what are the major improvements we're trying to achieve at <a href="https://www.igalia.com/">Igalia</a>. We're constantly putting in a lot of work to keep <a href="https://wpewebkit.org/">WPE</a> the best web engine available for embedded devices.
+This was a brief overview of how WPE rendering works, and also what are the major improvements we're trying to achieve at <a href="https://www.igalia.com/">Igalia</a>. We're constantly putting in a lot of work to keep WPE the best web engine available for embedded devices.
 
-If this post got you interested in collaborating with <a ref="https://wpewebkit.org/">WPE</a> development, or you are in need of a web engine to run on your embedded device, feel free to <a href="https://www.igalia.com/contact/">contact us</a>. We'll be pleased to help!
+If this post got you interested in collaborating with WPE development, or you are in need of a web engine to run on your embedded device, feel free to <a href="https://www.igalia.com/contact/">contact us</a>. We'll be pleased to help!
 
 We also have open positions at the WebKit team at <a href="https://www.igalia.com/">Igalia</a>. If you're motivated by this field and you're interested in developing your career around it, you can apply <a href="https://www.igalia.com/jobs/browsers_webkit_position">here</a>!

--- a/_posts/2022-07-28-blog-wpe-qa-tooling.md
+++ b/_posts/2022-07-28-blog-wpe-qa-tooling.md
@@ -6,7 +6,7 @@ author: lmoura
 permalink: /blog/04-wpe-qa-tooling.html
 ---
 
-In the previous posts, my colleagues Claudio and Miguel wrote respectively about the <a href="/blog/02-overview-of-wpe.html">major components</a> of the project and, specifically, the <a href="/blog/03-wpe-graphics-architecture.html">graphics architecture</a> of WPE. Today, you'll see our efforts to improve the quality of both WPE and the experience of working and using it. While the previous entries in this blog post series about <a href="https://wpewebkit.org/">WPE</a> aren't necessarily required in order to read this one, we recommend you to starting with the <a href="/blog/01-happy-birthday-wpe.html">first post in the series</a>.
+In the previous posts, my colleagues Claudio and Miguel wrote respectively about the <a href="{{ '/blog/02-overview-of-wpe.html' | url }}">major components</a> of the project and, specifically, the <a href="{{ '/blog/03-wpe-graphics-architecture.html' | url }}">graphics architecture</a> of WPE. Today, you'll see our efforts to improve the quality of both WPE and the experience of working and using it. While the previous entries in this blog post series about <a href="{{ '/' | url }}">WPE</a> aren't necessarily required in order to read this one, we recommend you to starting with the <a href="{{ '/blog/01-happy-birthday-wpe.html' | url }}">first post in the series</a>.
 
 ## Automated testing
 
@@ -32,15 +32,15 @@ Initially, the WPE [builder bots](https://build.webkit.org/#/builders?tags=%2BWP
 * WebDriver: Tests from [Selenium](https://www.selenium.dev/selenium/docs/api/py/index.html) and [W3C WebDriver](https://www.w3.org/TR/webdriver/) APIs for browser automation.
 * Other small suites: Tests for WebKit's tooling components.
 
-Due to a large number of tests and the fast development of both WebKit and the specifications - it's not uncommon to have dozens of daily commits touching dozens of tests - it's hard to keep the testing bots green.
+Due to a large number of tests and the fast development of both WebKit and the specifications&mdash;it's not uncommon to have dozens of daily commits touching dozens of tests&mdash;it's hard to keep the testing bots green.
 
-For example, while we try to make the tests work on all platforms, many old layout tests use the expected.txt scheme, where the render tree is printed in a textual format with the text sized in pixels for every node. While this works fine in most cases, many tests have minor differences between the expected result in the Mac platform and the WPE/GTK platform. One of the causes is the font rendering particularities of each port.
+For example, while we try to make the tests work on all platforms, many old layout tests use the `-expected.txt` scheme, where the render tree is printed in a textual format with the text sized in pixels for every node. While this works fine in most cases, many tests have minor differences between the expected result in the Mac platform and the WPE/GTK platform. One of the causes is the font rendering particularities of each port.
 
 Thankfully, this situation improved significantly since the beginning of the project. Among the efforts, many tests are now using a "reference" HTML file, which are HTML files that render to the same expected result as the test case, so both the test case and the reference will use the same font rendering scheme and can be compared pixel by pixel.
 
 ## Building and running WPE
 
-This section focuses on the experience of building and running WPE in a regular Linux x86_64 system. In a future post, we'll cover building for and running on embedded devices.
+This section focuses on the experience of building and running WPE in a regular Linux x86&ndash;64 system. In a future post, we'll cover building for and running on embedded devices.
 
 ### Checking out the code
 
@@ -116,21 +116,21 @@ After hacking locally, you can submit your changes following the workflow listed
 
 ## Testing WPE in the wild
 
-If you don't want to build your WPE build or image, there are some options to [get a taste of WPE](https://wpewebkit.org/about/exploring.html) listed on our website, including:
+If you don't want to build your WPE build or image, there are some options to [get a taste of WPE]({{ '/about/exploring.html' | url }}) listed on our website, including:
 
 * Prebuilt distribution packages
     * For [Debian](https://packages.debian.org/search?searchon=sourcenames&keywords=wpewebkit), [Ubuntu](https://packages.ubuntu.com/search?keywords=wpewebkit&searchon=sourcenames&suite=all&section=all), [Raspbian](https://archive.raspbian.org/raspbian/pool/main/w/wpewebkit/), [Arch Linux](https://archlinux.org/packages/extra/x86_64/wpewebkit/), and [Fedora](https://copr.fedorainfracloud.org/coprs/philn/wpewebkit/)
-* [Flatpak image](https://wpewebkit.org/about/flatpak.html)
+* [Flatpak image]({{ '/about/flatpak.html' | url }})
 * Prebuilt Raspberry Pi (3B, 3B+ and 4) images
     * For [stable](https://wk-contrib.igalia.com/debian/images/wpe-raspbian.img.zip) and [nightly](https://wk-contrib.igalia.com/debian/images/nightly/wpe-raspbian.img.zip) releases
-* [Balena blocks](https://wpewebkit.org/about/balena-wpe.html)
+* [Balena blocks]({{ '/about/balena-wpe.html' | url }})
 
 Some of these options, like the prebuilt images and the Balena blocks, will be the subject of future blog posts in this series.
 
 ## Final thoughts
 
-With this, we conclude this brief overview of <a ref="https://wpewebkit.org/">WPE</a> automated testing and the main tools we use in our daily work with WPE. In future posts in this area we'll go deeper in other subjects like testing on embedded boards and debugging practices.
+With this, we conclude this brief overview of WPE automated testing and the main tools we use in our daily work with WPE. In future posts in this area we'll go deeper in other subjects like testing on embedded boards and debugging practices.
 
-If this post got you interested in collaborating with <a ref="https://wpewebkit.org/">WPE</a> development, or you are in need of a web engine to run on your embedded device, feel free to <a href="https://www.igalia.com/contact/">contact us</a>. We'll be pleased to help!
+If this post got you interested in collaborating with WPE development, or you are in need of a web engine to run on your embedded device, feel free to <a href="https://www.igalia.com/contact/">contact us</a>. We'll be pleased to help!
 
 We also have open positions at the WebKit team at <a href="https://www.igalia.com/">Igalia</a>. If you're motivated by this field and you're interested in developing your career around it, you can apply <a href="https://www.igalia.com/jobs/browsers_webkit_position">here</a>!


### PR DESCRIPTION
Applies the following changes:

- Use `{{ '/some/path' | url }}` to generate links, which makes Eleventy generate valid links regardless of the path prefix and host name used during content generation (which makes previews work) and ensures the output always contains full URLs (good for consumption of content by feed readers.) This is applied to images as well.
- Avoid overlinking to ourselves, search engines have recognized such practices as an intention of artificially altering search results and will downrank pages using such practices.
- Made a few style edits here and there (e.g. “Cairo” is a proper name of the project so it goes with a capital letter, reformatted paragraphs to make them more legible in a text editor, and so on.)
- Make all images from articles centered.

----

Site preview: https://igalia.github.io/wpewebkit.org/aperezdc/mdcleanup/