### PR TITLE
Arrange for copying PGP key files, fix links

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -17,6 +17,7 @@ module.exports = function(eleventyConfig) {
   eleventyConfig.addPassthroughCopy('css')
   eleventyConfig.addPassthroughCopy('vendor')
   eleventyConfig.addPassthroughCopy('assets')
+  eleventyConfig.addPassthroughCopy('release/verify/*.key')
   eleventyConfig.addPlugin(pluginRss);
   
   eleventyConfig.setLiquidOptions({

--- a/release/verify/index.md
+++ b/release/verify/index.md
@@ -28,11 +28,11 @@ The following PGP keys are currently in use for signing releases:
     <tr><th>Developer</th><th>Fingerprint</th></tr>
   </thead>
     <tr>
-      <td>Adrián Pérez de Castro (<a href="aperez.key">key</a>)</td>
+      <td>Adrián Pérez de Castro (<a href="{{ '/release/verify/aperez.key' | url }}">key</a>)</td>
       <td><tt>5AA3 BC33 4FD7 E336 9E7C  77B2 91C5 59DB E4C9 123B</tt></td>
     </tr>
     <tr>
-      <td>Carlos García Campos (<a href="carlosgc.key">key</a>)</td>
+      <td>Carlos García Campos (<a href="{{ '/release/verify/carlosgc.key' | url }}">key</a>)</td>
       <td><tt>D7FC F61C F9A2 DEAB 31D8  1BD3 F3D3 22D0 EC45 82C3</tt></td>
     </tr>
   <tbody>


### PR DESCRIPTION
Make Eveventy copy PGP `.key` files to the output directory as-is, and ensure that the links are valid by using the `url` filter.

----

Site preview: https://igalia.github.io/wpewebkit.org/aperezdc/fix-keyfile-copy/