### PR TITLE
Update cog compatibility for WebKit 2.38.x

### DIFF
--- a/release/schedule/index.md
+++ b/release/schedule/index.md
@@ -49,12 +49,12 @@ version number stays the same:
 
 The following table summarizes which *stable* releases of libwpe, WPE WebKit,
 WPEBackend-fdo, and Cog are compatible and tested with each other (updated
-September 2022). Distributors and packagers are strongly advised to use the
+December 2022). Distributors and packagers are strongly advised to use the
 versions listed below.
 
 | **WPE WebKit** | **libwpe**   | **WPEBackend-fdo** | **Cog**      |
 |:--------------:|:------------:|:------------------:|:------------:|
-| 2.38.x         | 1.14.x, 1.12.x | 1.14.x, 1.12.x, 1.10.x | 0.14.x, 0.12.x |
+| 2.38.x         | 1.14.x, 1.12.x | 1.14.x, 1.12.x, 1.10.x | 0.16.x, 0.14.x, 0.12.x |
 | 2.36.x         | 1.12.x, 1.10.x | 1.12.x, 1.10.x | 0.14.x, 0.12.x, 0.10.x | 
 | 2.34.x         | 1.12.x, 1.10.x, 1.8.x | 1.12.x, 1.10.x | 0.12.x, 0.10.x, 0.8.x |
 | 2.32.x         | 1.10.x, 1.8.x, 1.6.x | 1.10.x, 1.8.x | 0.10.x, 0.8.x |


### PR DESCRIPTION
cog 0.16.x is stable and at least I'm using it sucessfully with wpewebkit 2.38.x, so update the compatibility table accordingly.