### PR TITLE
Add Mastodon link in the page footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,7 +3,7 @@
 	<div>
 		<a href="{{ '/' | url }}" class="igalia logo home"><img src="{{ '/assets/img/logo-white.svg' | url }}" alt="WPE"></a>
 		<ul>
-			<li>Connect on <a href="https://twitter.com/WPEWebKit">Twitter</a></li>
+			<li>Connect on <a rel="me" href="https://floss.social/@WPEWebKit">Mastodon</a>, <a href="https://twitter.com/WPEWebKit">Twitter</a></li>
 			<li>mailing list: <a href="https://lists.webkit.org/mailman/listinfo/webkit-wpe">webkit-wpe</a></li>
 			<li>OFTC: <a href="https://webchat.oftc.net/?channels=wpe">#wpe</a></li>
 			<li>Matrix: <a href="https://matrix.to/#/#wpe:matrix.org">#wpe:matrix.org</a></li>


### PR DESCRIPTION
The link also includes `rel="me"`, which can be used for cross-validating that we are who we claim to be in the fediverse.

This is related to #130 

----

Site preview: https://igalia.github.io/wpewebkit.org/aperezdc/fedi/