### PR TITLE
Fix link to Carlos García Campos' key

### DIFF
--- a/release/verify/index.md
+++ b/release/verify/index.md
@@ -32,7 +32,7 @@ The following PGP keys are currently in use for signing releases:
       <td><tt>5AA3 BC33 4FD7 E336 9E7C  77B2 91C5 59DB E4C9 123B</tt></td>
     </tr>
     <tr>
-      <td>Carlos García Campos (<a href="{{ '/release/verify/carlosgc.key' | url }}">key</a>)</td>
+      <td>Carlos García Campos (<a href="{{ '/release/verify/cgarcia.key' | url }}">key</a>)</td>
       <td><tt>D7FC F61C F9A2 DEAB 31D8  1BD3 F3D3 22D0 EC45 82C3</tt></td>
     </tr>
   <tbody>


### PR DESCRIPTION
The current link to @carlosgcampos' key is broken, so make the link point to the correct file.

On a different note: Since the redesign (#123), I can't find a link to https://wpewebkit.org/release/verify/ anymore. Is this on purpose?