### PR TITLE
rpi-yocto: remove reference to bmaptool, add dd instr for rpi4-64

### DIFF
--- a/about/rpi-yocto-wpe.md
+++ b/about/rpi-yocto-wpe.md
@@ -38,12 +38,19 @@ wget https://wk-contrib.igalia.com/yocto/meta-webkit/browsers/stable/images/rasp
 To write with '`dd`' (replace '`mmcblk_XYZ`' with your actual target
 device) and use the downloaded image, for example:
 
+#### Raspberry Pi 4 (64-bit)
+
 ```
-bzip2 -d core-image-weston-browsers-raspberrypi3-mesa_202205_4.0_kirkstone_r1_20221228073347.wic.bz2
-sudo dd if=core-image-weston-browsers-raspberrypi3-mesa_202205_4.0_kirkstone_r1_20221228073347.wic of="/dev/mmcblk_XYZ" bs=4k status=progress
+bzip2 -d core-image-weston-browsers-raspberrypi4-64-mesa_202205_4.0_kirkstone_r1_20221228073347.wic.bz2
+sudo dd if=core-image-weston-browsers-raspberrypi4-64-mesa_202205_4.0_kirkstone_r1_20221228073347.wic of="/dev/mmcblk_XYZ" bs=4M status=progress
 ```
 
-'`bmaptool`' can also be used and is typically (faster), we also provide the `.bmap` files to download.
+#### Raspberry Pi 3B/3B+ (32-bit)
+
+```
+bzip2 -d core-image-weston-browsers-raspberrypi3-mesa_202205_4.0_kirkstone_r1_20221228073347.wic.bz2
+sudo dd if=core-image-weston-browsers-raspberrypi3-mesa_202205_4.0_kirkstone_r1_20221228073347.wic of="/dev/mmcblk_XYZ" bs=4M status=progress
+```
 
 ## Set-up
 


### PR DESCRIPTION
When discussing in a meeting, the reference to bmaptool was deemed confusing without providing links to bmap files, at which point everything start to be less flexible and more messy.

Also add instructions for flashing the rpi-64 image, the flashing instructions were meant to be generic but since we're using a specific image name, and we only have 2 in total anyway, make it convenient for all the devices.

----

Site preview: https://igalia.github.io/wpewebkit.org/manuelafm-patch-1/