### PR TITLE
CI: Bump to versions of actions that use Node 16

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,20 +9,13 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: '16.x'
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Cache Node modules
-        uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: npm-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            npm-${{ runner.os }}-
-            npm-
+          cache: 'npm'
       - name: Install Node modules
         run: npm install
       - name: Eleventy

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,20 +9,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Setup Node
-        uses: actions/setup-node@v1
-        with:
-          node-version: '16.x'
       - name: Checkout
-        uses: actions/checkout@v2
-      - name: Cache Node modules
-        uses: actions/cache@v2
+        uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
         with:
-          path: ~/.npm
-          key: npm-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            npm-${{ runner.os }}-
-            npm-
+          node-version: 16
+          cache: 'npm'
       - name: Install Node modules
         run: npm install
       - name: Eleventy
@@ -41,11 +34,11 @@ jobs:
           publish_dir: ./_site
           keep_files: true
       - name: Add deploy link
-        uses: actions/github-script@v2
+        uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const { data: pr } = await github.pulls.get({
+            const { data: pr } = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: context.issue.number,
@@ -56,7 +49,7 @@ jobs:
             if (pr.body && pr.body.indexOf(marker) != -1)
               return;
 
-            await github.pulls.update({
+            await github.rest.pulls.update({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: pr.number,


### PR DESCRIPTION
Update to newer versions of the actions used by the CI workflows, in order to avoid warnings due to using Node older than version 16. While at it, remove uses of `actions/cache` in favor of the `cache: 'npm'` parameter to the `setup-node` action.

----

Site preview: https://igalia.github.io/wpewebkit.org/aperezdc/update-gha/