### PR TITLE
CI: Give actions write permission to page contents

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,7 +1,7 @@
 name: build-pr
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - master
 


### PR DESCRIPTION
According to https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/ using `pull_request_target` will use the base branch instead of the fork branch. The base branch is considered trusted, and the automatic token handed over to GHA will include write permission.

Fixes #153