### PR TITLE
Add XML sitemap and robots.txt for web crawlers

### DIFF
--- a/about/a-good-choice.md
+++ b/about/a-good-choice.md
@@ -4,6 +4,7 @@ title: "Why Choose WPE?"
 tags: [about]
 data: { dateless: "true" }
 permalink: /about/a-good-choice.html
+sitemapChangeFrequency: yearly
 ---
 <style>
 :not(header) > h2 {

--- a/about/architecture.md
+++ b/about/architecture.md
@@ -4,6 +4,7 @@ title: "The Architecture of WPE"
 tags: [about]
 data: { dateless: "true" }
 permalink: /about/architecture.html
+sitemapChangeFrequency: yearly
 ---
 <style>
 main > *, .dotsep {

--- a/about/builds.md
+++ b/about/builds.md
@@ -4,6 +4,7 @@ title: "WPE Builds"
 tags: [about]
 data: { dateless: "true" }
 permalink: /about/builds.html
+sitemapChangeFrequency: yearly
 ---
 
 While there are several [simple ways for developers to experiment with and explore WPE](/about/exploring.html), none are tuned for performance. Generally, shipping products for embedded systems are performance-tuned custom builds.  To make this easier, there is also [meta-webkit](https://github.com/Igalia/meta-webkit), which provides build recipes, WebKit based runtimes, and browsers for use with OpenEmbedded and/or Yocto.

--- a/about/explore-wpe.md
+++ b/about/explore-wpe.md
@@ -4,6 +4,7 @@ title: "Get Started with WPEwebkit"
 tags: [about]
 data: { dateless: "true" }
 permalink: /about/explore-wpe.html
+sitemapChangeFrequency: yearly
 resources: [
 	{
 		"title": "Package Releases",

--- a/about/faq.md
+++ b/about/faq.md
@@ -4,6 +4,7 @@ title: "WPE's Frequently Asked Questions"
 tags: [about]
 data: { dateless: "true" }
 permalink: /about/faq.html
+sitemapChangeFrequency: monthly
 ---
 
 [[toc]]

--- a/about/index.md
+++ b/about/index.md
@@ -4,6 +4,8 @@ title: "Learn & Discover"
 tags: [learn]
 data: { dateless: "true" }
 permalink: /about/
+sitemapChangeFrequency: yearly
+sitemapPriority: 0.9
 --- 
 <style>
 @media (min-width: 30rem) {

--- a/about/supported-hardware.md
+++ b/about/supported-hardware.md
@@ -4,6 +4,8 @@ title: "Supported Hardware"
 tags: [about] 
 data: { dateless: "true" }
 permalink: /about/supported-hardware.html 
+sitemapChangeFrequency: monthly
+sitemapPriority: 0.7
 resources: [
 	{
 		"title": "Why Choose WPE?",

--- a/about/what-is-embedded.md
+++ b/about/what-is-embedded.md
@@ -4,6 +4,7 @@ title: "What is an Embedded Browser?"
 tags: [about]
 data: { dateless: "true" }
 permalink: /about/what-is-embedded.html
+sitemapChangeFrequency: yearly
 --- 
 
 <header class="page">

--- a/blog.md
+++ b/blog.md
@@ -4,6 +4,8 @@ title: "Blog"
 tags: [blog]
 data: { dateless: "true" }
 permalink: /blog/
+sitemapChangeFrequency: weekly
+sitemapPriority: 0.9
 ---
 <style>
 .card ol {

--- a/code.md
+++ b/code.md
@@ -4,6 +4,7 @@ title: "Code"
 tags: [about]
 data: { dateless: "true" }
 permalink: /code/
+sitemapChangeFrequency: yearly
 ---
 
 <header class="page">

--- a/developers/index.md
+++ b/developers/index.md
@@ -3,6 +3,7 @@ title: "Developers"
 layout: page
 tags: [devs]
 data: { dateless: "true" }
+sitemapChangeFrequency: yearly
 ---
 <style>
 header.page h1 {

--- a/index.html
+++ b/index.html
@@ -2,6 +2,8 @@
 layout: home.html
 title: WPE
 description: WebKit port optimized for embedded devices
+sitemapPriority: 1.0
+sitemapChangeFrequency: yearly
 ---
 <style>
 

--- a/release.md
+++ b/release.md
@@ -1,6 +1,8 @@
 ---
 title: Releases
 layout: page
+sitemapChangeFrequency: yearly
+sitemapPriority: 0.7
 ---
 <header class="page">
 

--- a/release/schedule/index.md
+++ b/release/schedule/index.md
@@ -1,6 +1,8 @@
 ---
 layout: post
 title: Release Schedule
+sitemapChangeFrequency: yearly
+sitemapPriority: 0.4
 ---
 
 WPE WebKit follows a 6-month development cycle:

--- a/release/verify/index.md
+++ b/release/verify/index.md
@@ -2,6 +2,8 @@
 title: Verifying Releases
 layout: post
 data: { dateless: "true" }
+sitemapChangeFrequency: yearly
+sitemapPriority: 0.4
 ---
 
 WPE release tarballs are cryptographically signed and can be verified

--- a/robots.liquid
+++ b/robots.liquid
@@ -1,0 +1,9 @@
+---
+eleventyExcludeFromCollections: true
+permalink: /robots.txt
+---
+User-Agent: *
+Allow: /
+Disallow: /reference/
+Disallow: /releases/
+Sitemap: {{ "/sitemap.xml" | htmlBaseUrl: site.base_url }}

--- a/security.md
+++ b/security.md
@@ -1,6 +1,7 @@
 ---
 title: Security Advisories
 layout: page
+sitemapChangeFrequency: monthly
 pagination:
   data: collections.WSA
   size: 50

--- a/sitemap.liquid
+++ b/sitemap.liquid
@@ -1,0 +1,15 @@
+---
+eleventyExcludeFromCollections: true
+permalink: /sitemap.xml
+---
+<?xml version="1.0" encoding="utf-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+{% for item in collections.all %}
+	<url>
+		<loc>{{ item.url | htmlBaseUrl: site.base_url }}</loc>
+		<lastmod>{{ item.date | isodate }}</lastmod>
+		<changefreq>{{ item.data.sitemapChangeFrequency | default: "monthly" }}</changefreq>
+		<priority>{{ item.data.sitemapPriority | default: 0.5 }}</priority>
+	</url>
+{% endfor %}
+</urlset>


### PR DESCRIPTION
These are good to have, and an initial step towards having some kind of site map. At some point later on we would want to also have an HTML site map that is user-visible (instead of machine-readable like this), but that is left for a future PR.

----

Site preview: https://igalia.github.io/wpewebkit.org/aperezdc/xmlsitemap-and-robotstxt/