### PR TITLE
blog: Move posts into their own subdirectory, add pagination 

### DIFF
--- a/blog.md
+++ b/blog.md
@@ -3,9 +3,13 @@ layout: page
 title: "Blog"
 tags: [blog]
 data: { dateless: "true" }
-permalink: /blog/
 sitemapChangeFrequency: weekly
 sitemapPriority: 0.9
+pagination:
+  data: collections.blogpost
+  reverse: true
+  size: 6
+permalink: /blog/{% if pagination.pageNumber > 0 %}{{ (pagination.pageNumber + 1) }}/{% endif %}
 ---
 <style>
 .card ol {
@@ -40,11 +44,9 @@ and the Web platform. Also check out [the official WebKit blog](https://webkit.o
 
 </header>
 
-## Recent Articles
-
 <div class="card">
 	<ol reversed role="list" class="w-list-unstyled" style="margin: 1rem 0 1rem 0; list-style: none;">
-	{%- for blogPost in collections.recentBlogPosts -%}
+	{%- for blogPost in pagination.items -%}
 		<li class="listitem">
 			<img src="{{ blogPost.data.thumbnail }}" alt="">
 			<time>{{ blogPost.date | postDate }}</time>
@@ -53,6 +55,17 @@ and the Web platform. Also check out [the official WebKit blog](https://webkit.o
 		</li>
 	{%- endfor -%}
 	</ol>
+
+  <nav class="pagination">
+    <ol>
+      <li>{% if pagination.href.previous %}<a href="{{ pagination.href.previous }}" title="Previous">«</a>{% else %}<span>«</span>{% endif %}</li>
+      {%- for pageEntry in pagination.pages %}
+      <li><a href="{{ pagination.hrefs[ forloop.index0 ] }}"{% if page.url == pagination.hrefs[ forloop.index0 ] %} aria-current="page"{% endif %}>{{ forloop.index }}</a></li>
+      {%- endfor %}
+      <li>{% if pagination.href.next %}<a href="{{ pagination.href.next }}" title="Next">»</a>{% else %}<span>»</span>{% endif %}</li>
+    </ol>
+  </nav>
+
 	<a class="btn" href="/blog.xml"><i class="icon-feed"></i>&nbsp;&nbsp;Feed</a>
 </div>
 

--- a/blog/2022-04-21-blog-happy-birthday-wpe.md
+++ b/blog/2022-04-21-blog-happy-birthday-wpe.md
@@ -1,7 +1,5 @@
 ---
-layout: post
 title: "Happy birthday WPE!"
-tags: [blogpost]
 author: nzimmermann
 permalink: /blog/01-happy-birthday-wpe.html
 preview: Welcome to the new Blog section on wpewebkit.org! Let's take some time to celebrate and recap how WPE evolved from the early prototyping days to the product empowering hundreds of millions of devices worldwide today.

--- a/blog/2022-07-01-blog-overview-of-wpe.md
+++ b/blog/2022-07-01-blog-overview-of-wpe.md
@@ -1,7 +1,5 @@
 ---
-layout: post
 title: "An overview of the WPE WebKit project"
-tags: [blogpost]
 author: csaavedra
 permalink: /blog/02-overview-of-wpe.html
 preview: In <a href="/blog/01-happy-birthday-wpe.html">the previous post in this series</a>, we explained that WPE is a WebKit port optimized for embedded devices. In this post, we'll dive into a more technical overview of the different components of WPE, WebKit, and how they all fit together.

--- a/blog/2022-07-15-blog-wpe-graphics-architecture.md
+++ b/blog/2022-07-15-blog-wpe-graphics-architecture.md
@@ -1,7 +1,5 @@
 ---
-layout: post
 title: "WPE Graphics architecture"
-tags: [blogpost]
 author: magomez
 permalink: /blog/03-wpe-graphics-architecture.html
 preview: Following <a href="/blog/02-overview-of-wpe.html">the previous post in the series about <a href="https://wpewebkit.org/">WPE</a> where we talked about the <a href="https://wpewebkit.org/">WPE</a> components, this post will explain briefly the <a href="https://wpewebkit.org/">WPE</a> graphics architecture, and how the engine is able to render HTML content into the display.

--- a/blog/2022-07-28-blog-wpe-qa-tooling.md
+++ b/blog/2022-07-28-blog-wpe-qa-tooling.md
@@ -1,7 +1,5 @@
 ---
-layout: post
 title: "WPE QA and tooling"
-tags: [blogpost]
 author: lmoura
 permalink: /blog/04-wpe-qa-tooling.html
 preview: In the previous posts, my colleagues Claudio and Miguel wrote respectively about the <a href="/blog/02-overview-of-wpe.html">major components</a> of the project and, specifically, the <a href="/blog/03-wpe-graphics-architecture.html">graphics architecture</a> of WPE. Today, you'll see our efforts to improve the quality of both WPE and the experience of working and using it.

--- a/blog/2022-09-29-blog-wpe-networking-overview.md
+++ b/blog/2022-09-29-blog-wpe-networking-overview.md
@@ -1,7 +1,5 @@
 ---
-layout: post
 title: "WPE Networking Overview"
-tags: [blogpost]
 author: pgriffis
 permalink: /blog/04-wpe-networking-overview.html
 thumbnail: /assets/networking-layers.svg

--- a/blog/2022-10-success-metrological.md
+++ b/blog/2022-10-success-metrological.md
@@ -1,8 +1,7 @@
 ---
-layout: post
 title: "Success Story: Metrological"
 date: 2022-10-15
-tags: [blogpost, success]
+tags: success
 permalink: /blog/2022-success-metrological.html
 preview: WPE WebKit brought RDK (Reference Design Kit), a modern, performant web browser, to millions of screens.
 thumbnail: /assets/img/logo-metrological@2x.png

--- a/blog/2023-01-19-blog-new-svg-engine.md
+++ b/blog/2023-01-19-blog-new-svg-engine.md
@@ -1,7 +1,5 @@
 ---
-layout: post
 title: "Status of the new SVG engine in WebKit"
-tags: [blogpost]
 author: nzimmermann
 permalink: /blog/05-new-svg-engine.html
 thumbnail: /assets/lbse-logo-wide.png

--- a/blog/blog-06-integrating-wpe.md
+++ b/blog/blog-06-integrating-wpe.md
@@ -1,7 +1,5 @@
 ---
-layout: post
 title: "Integrating WPE: URI Scheme Handlers and Script Messages"
-tags: [blogpost]
 author: aperez
 date: 2023-03-07
 permalink: /blog/06-integrating-wpe.html

--- a/blog/blog.json
+++ b/blog/blog.json
@@ -1,0 +1,6 @@
+{
+	"layout": "post",
+	"tags": ["blogpost"],
+	"sitemapChangeFrequency": "yearly",
+	"sitemapPriority": 0.75
+}

--- a/css/v2.css
+++ b/css/v2.css
@@ -625,6 +625,40 @@ footer.global div > :last-child {
 	grid-column: span 2;
 }
 
+nav.pagination {
+	display: block;
+	color: #88b;
+	padding: 0;
+	margin: 0;
+	text-align: center;
+	font-feature-settings: "pnum" 0;
+}
+nav.pagination > ol {
+	display: inline-block;
+	padding: 0;
+	margin: 0;
+}
+nav.pagination > ol > li {
+	display: inline-block;
+	padding: 0;
+	margin: 0;
+}
+nav.pagination > ol > li > a,
+nav.pagination > ol > li > span {
+	display: inline;
+	text-decoration: none;
+	margin: 0;
+	padding: 0.35rem 0.75rem;
+	font-weight: normal;
+}
+nav.pagination > ol > li > a:hover {
+	background-color: #eaeaee;
+}
+nav.pagination > ol > li > a[aria-current="page"] {
+	background-color: var(--colorMain);
+	color: #eef;
+}
+
 @media (min-width: 50rem) {
 	footer.global div {
 		grid-template-columns: minmax(125px, auto) repeat(2,max-content);


### PR DESCRIPTION
This contains two changes:

- The first commit moves the blog content into the `blog/` subdirectory, for the sake of easiness of maintenance (we may want to do the same for releases and WSAs at some point).
- The second commit adds pagination to the blog section, with a pagination navigation widget, and the corresponding CSS rules.

The CSS styling is quite minimal, and probably could be done better, but we can iterate on that on follow-up patches. If there are any suggestions for the styling that would be quick to include in this PR, please let me know.

The page navigation looks like this:

![Screenshot from 2023-04-01 01-28-51](https://user-images.githubusercontent.com/723451/229244560-97ffbb0e-76e3-49a8-9deb-6dc804ed04e1.png)


----

Site preview: https://igalia.github.io/wpewebkit.org/aperezdc/paginate-blog/