### PR TITLE
Fix width of sticky nav on about page (and subpages)

### DIFF
--- a/css/v2.css
+++ b/css/v2.css
@@ -424,6 +424,7 @@ nav.sidebar .currentPage a[href] {
 	}
 	nav.sidebar ul {
 		display: block;
+		width: max-content;
 	}
 	nav.sidebar a[href] {
 		display: block;


### PR DESCRIPTION
The `ul` inside the sticky nav was covering the whole width of the content, which was making the underlying hyperlinks and text unreachable for the mouse:

![image](https://user-images.githubusercontent.com/6615143/230434006-a0ba2c2e-b056-4300-b325-e230ea24ddfb.png)

Setting the width of `ul` to `max-content` limits its size, and thus solves the issue.

----

Site preview: https://igalia.github.io/wpewebkit.org/sticky-nav-fix/