### PR TITLE
Fix typo in 2023-04-19-wpewebkit-2.40.1-released.md

### DIFF
--- a/release/2023-04-19-wpewebkit-2.40.1-released.md
+++ b/release/2023-04-19-wpewebkit-2.40.1-released.md
@@ -17,7 +17,7 @@ This is the first bug fix release in the stable 2.40 series.
   is still recommended, but optional.
 - Improvements to the GStreamer multimedia playback, in particular
   around MSE, WebRTC, and seeking.
-- Make all supported image ypes appear in the `Accept` HTTP header.
+- Make all supported image types appear in the `Accept` HTTP header.
 - Long touch presses no longer generate mouse click events, to align
   with other web engines and WebKit ports.
 - Fix default database quota size definition.


### PR DESCRIPTION
null

----

Site preview: https://igalia.github.io/wpewebkit.org/manuelafm-patch-1/