### PR TITLE
release/schedule: Update compatibility table for 2.40

### DIFF
--- a/release/schedule/index.md
+++ b/release/schedule/index.md
@@ -51,11 +51,12 @@ version number stays the same:
 
 The following table summarizes which *stable* releases of libwpe, WPE WebKit,
 WPEBackend-fdo, and Cog are compatible and tested with each other (updated
-December 2022). Distributors and packagers are strongly advised to use the
+April 2023). Distributors and packagers are strongly advised to use the
 versions listed below.
 
 | **WPE WebKit** | **libwpe**   | **WPEBackend-fdo** | **Cog**      |
 |:--------------:|:------------:|:------------------:|:------------:|
+| 2.40.x         | 1.14.x, 1.12.x | 1.14.x, 1.12.x | 0.16.x |
 | 2.38.x         | 1.14.x, 1.12.x | 1.14.x, 1.12.x, 1.10.x | 0.16.x, 0.14.x, 0.12.x |
 | 2.36.x         | 1.12.x, 1.10.x | 1.12.x, 1.10.x | 0.14.x, 0.12.x, 0.10.x | 
 | 2.34.x         | 1.12.x, 1.10.x, 1.8.x | 1.12.x, 1.10.x | 0.12.x, 0.10.x, 0.8.x |


### PR DESCRIPTION
Add component versions compatibility entry for WPE WebKit 2.40.x.

----

Site preview: https://igalia.github.io/wpewebkit.org/aperezdc/update-compat-table/