### PR TITLE
Fix regex in `topLevel` filter to match global nav links

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -44,7 +44,7 @@ module.exports = function(eleventyConfig) {
   });
   eleventyConfig.addFilter('topLevel', (path) => {
     if (path == "/") return "/";
-    return path.match(/^(.+?)\//)[1];
+    return path.match(/^(.+?\/)/)[1];
   });
 
   eleventyConfig.addShortcode("currentYear", () => `${new Date().getFullYear()}`);

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,7 +1,7 @@
 <nav class="global">
 	<div>
 		<a class="igalia logo home" href="/"><img src="/assets/img/logo-blue.svg" alt="WPE"></a>
-		<ul class="{{ page.url | topLevel | replace_first: "/","" }} off">
+		<ul class="{{ page.url | topLevel | replace: "/","" }} off">
 		{%- for link in menu -%}
 			{%- assign pagedir = page.url | topLevel -%}
 			<li{% if link.url == pagedir %} class="currentPage"{% endif %}>


### PR DESCRIPTION
In the global navigation, the `currentPage` class is applied to a link if the link's URL matches `page.url | topLevel`. This `topLevel` filter was excluding the trailing slash, resulting in no nav item getting the `currentPage` class (except `/`). Tweaking the regex in the `topLevel` filter fixes this.

The `ul` in the global navigation was also generating a class name based on the `topLevel` filter, so changed its `replace_first` filter to `replace` to accommodate accordingly.

(Also, I noticed that the link for the "Getting Started" page in the global navigation would never receive the `currentPage` class because its URL matches with `/about/`. Thus, when clicking on "Getting Started", the dashed line (indicating the current page) appears under "About" instead of "Getting Started", which is a bit jarring, but is probably by design?)

----

Site preview: https://igalia.github.io/wpewebkit.org/nav-current-page/