### PR TITLE
[blog] Remove the dangling Feed link and use link rel instead

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -31,6 +31,7 @@
   {%- endif %}
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | htmlBaseUrl: site.base_url }}">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ '/feed.xml' | htmlBaseUrl: site.base_url  }}">
+  <link rel="alternate" type="application/rss+xml" title="WPE blog" href="{{ '/blog.xml' | htmlBaseUrl: site.base_url  }}">
 
   {%- comment %}
   <!-- OpenGraph metadata, see https://ogp.me -->

--- a/blog.md
+++ b/blog.md
@@ -65,8 +65,6 @@ and the Web platform. Also check out [the official WebKit blog](https://webkit.o
       <li>{% if pagination.href.next %}<a href="{{ pagination.href.next }}" title="Next">»</a>{% else %}<span>»</span>{% endif %}</li>
     </ol>
   </nav>
-
-	<a class="btn" href="/blog.xml"><i class="icon-feed"></i>&nbsp;&nbsp;Feed</a>
 </div>
 
 


### PR DESCRIPTION
Remove the ugly link at the bottom of the blog and add syndication metadata to the header so that it's available in every page instead.

Fixes #174 

----

Site preview: https://igalia.github.io/wpewebkit.org/csaavedra/blog-feed-link/