### PR TITLE
Hacked a way to link dashed line to Get Started

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -3,7 +3,10 @@
 		<a class="igalia logo home" href="/"><img src="/assets/img/logo-blue.svg" alt="WPE"></a>
 		<ul class="{{ page.url | topLevel | replace: "/","" }} off">
 		{%- for link in menu -%}
+			{%- assign pagedir = page.url -%}
+			{%- if page.url != '/about/explore-wpe.html' -%}
 			{%- assign pagedir = page.url | topLevel -%}
+			{%- endif -%}
 			<li{% if link.url == pagedir %} class="currentPage"{% endif %}>
 			<a class="{{ link.class | default: 'nav-link' }}" href="{{ link.url | default: '#' }}">{{ link.title }}</a>
 			</li>

--- a/css/v2.css
+++ b/css/v2.css
@@ -151,6 +151,10 @@ ul.arrows li::before {
 	text-decoration: none;
 	filter: none;
 }
+.currentPage .cta.btn {
+	box-shadow: none;
+}
+
 
 .global a.igalia.logo.home {
 	transform: translateX(10px);


### PR DESCRIPTION
Closes #188

This does cause the button to not look like a button on the Get Started page, but like all the other links.  This was forced by the existing CSS, and may be desirable anyway, since it keeps the Call-To-Action button from looking like a Call To Action on the page it’s trying to get you to visit.  If it must continue to look like a button, even on its own page, significant rewriting of the template script and CSS will probably be needed.

----

Site preview: https://igalia.github.io/wpewebkit.org/issue-188/