### PR TITLE
Alternative use case/success story resolution

### DIFF
--- a/index.html
+++ b/index.html
@@ -168,6 +168,10 @@ header.page div h1 {
 	padding: 0.75em 0;
 	font-size: 1.4em;
 }
+.success-stories h3 {
+	font-size: 1.33em;
+	margin-block-start: 0;
+}
 .success-stories h3 a {
   font-size: 3em;
   color: inherit;
@@ -193,8 +197,8 @@ header.page div h1 {
 		padding: 0;
 	}
 	.success-stories img.hero {
-		height: 100%;
-		max-width: none;
+		max-width: 100%;
+		height: auto;
 		max-height: 30rem;
 		margin-inline-start: -5rem;
 		box-shadow: -0.25em 0 0.5em #06C3, 1em 1.5em 2.5em #0066DD99;
@@ -334,7 +338,7 @@ Open standards with great longevity allows lots more things to benefit from the 
 </div>
 <img src="/assets/img/use_case-digital_signage.png" alt="">
 </div><div>
-<img src="/assets/img/Metrological-hero.jpg" alt="" class="hero" style="max-width: 761px;">
+<img src="/assets/img/Metrological-hero.jpg" alt="" class="hero">
 <div class="spotlight"><h2>Success Story</h2>
 
 <h3><a href="/blog/2022-success-metrological.html"><img src="/assets/img/logo-metrological@2x.png" alt="Metrological"></a></h3>

--- a/index.html
+++ b/index.html
@@ -324,6 +324,7 @@ Open standards with great longevity allows lots more things to benefit from the 
 
 
 <section class="success-stories full-width dotsep">
+
 <div>
 <div class="spotlight">
 <h2>Use Case</h2>
@@ -332,7 +333,15 @@ Open standards with great longevity allows lots more things to benefit from the 
 <p><a href="/blog/2023-success-digital-signage.html" class="cta btn large">Learn More</a></p>
 </div>
 <img src="/assets/img/use_case-digital_signage.png" alt="">
+</div><div>
+<img src="/assets/img/Metrological-hero.jpg" alt="" class="hero" style="max-width: 761px;">
+<div class="spotlight"><h2>Success Story</h2>
+
+<h3><a href="/blog/2022-success-metrological.html"><img src="/assets/img/logo-metrological@2x.png" alt="Metrological"></a></h3>
+<p>WPE WebKit brought RDK, a modern, performant web browser, to millions of screens. It enables operators to manage devices and easily customize their UIs and apps and provides analytics to improve the customer experience and drive business results.</p>
+<p><a href="/blog/2022-success-metrological.html" class="cta btn large">Read Success Story</a></p></div>
 </div>
+
 </section>
 
 

--- a/index.html
+++ b/index.html
@@ -183,6 +183,12 @@ header.page div h1 {
 	object-fit: cover;
 	object-position: 50% 50%;
 }
+.success-stories div + img {
+	max-height: 20rem;
+	display: block;
+	margin-inline: auto;
+}
+
 @media (min-width: 45rem) {
 	.success-stories > div {
 		grid-column: main / -2;
@@ -195,6 +201,10 @@ header.page div h1 {
 	.success-stories > * {
 		margin: 0;
 		padding: 0;
+	}
+	.success-stories div + img {
+		max-height: 100%;
+		margin-inline: 0;
 	}
 	.success-stories img.hero {
 		max-width: 100%;
@@ -337,10 +347,10 @@ Open standards with great longevity allows lots more things to benefit from the 
 <p><a href="/blog/2023-success-digital-signage.html" class="cta btn large">Learn More</a></p>
 </div>
 <img src="/assets/img/use_case-digital_signage.png" alt="">
-</div><div>
+</div>
+<div>
 <img src="/assets/img/Metrological-hero.jpg" alt="" class="hero">
 <div class="spotlight"><h2>Success Story</h2>
-
 <h3><a href="/blog/2022-success-metrological.html"><img src="/assets/img/logo-metrological@2x.png" alt="Metrological"></a></h3>
 <p>WPE WebKit brought RDK, a modern, performant web browser, to millions of screens. It enables operators to manage devices and easily customize their UIs and apps and provides analytics to improve the customer experience and drive business results.</p>
 <p><a href="/blog/2022-success-metrological.html" class="cta btn large">Read Success Story</a></p></div>

--- a/index.html
+++ b/index.html
@@ -340,6 +340,15 @@ Open standards with great longevity allows lots more things to benefit from the 
 <section class="success-stories full-width dotsep">
 
 <div>
+<img src="/assets/img/Metrological-hero.jpg" alt="" class="hero">
+<div class="spotlight"><h2>Success Story</h2>
+<h3><a href="/blog/2022-success-metrological.html"><img src="/assets/img/logo-metrological@2x.png" alt="Metrological"></a></h3>
+<p>WPE WebKit brought RDK, a modern, performant web browser, to millions of screens. It enables operators to manage devices and easily customize their UIs and apps and provides analytics to improve the customer experience and drive business results.</p>
+<p><a href="/blog/2022-success-metrological.html" class="cta btn large">Read Success Story</a></p>
+</div>
+</div>
+
+<div>
 <div class="spotlight">
 <h2>Use Case</h2>
 <h3><a href="/blog/2023-success-digital-signage.html">Digital Signage</a></h3>
@@ -347,13 +356,6 @@ Open standards with great longevity allows lots more things to benefit from the 
 <p><a href="/blog/2023-success-digital-signage.html" class="cta btn large">Learn More</a></p>
 </div>
 <img src="/assets/img/use_case-digital_signage.png" alt="">
-</div>
-<div>
-<img src="/assets/img/Metrological-hero.jpg" alt="" class="hero">
-<div class="spotlight"><h2>Success Story</h2>
-<h3><a href="/blog/2022-success-metrological.html"><img src="/assets/img/logo-metrological@2x.png" alt="Metrological"></a></h3>
-<p>WPE WebKit brought RDK, a modern, performant web browser, to millions of screens. It enables operators to manage devices and easily customize their UIs and apps and provides analytics to improve the customer experience and drive business results.</p>
-<p><a href="/blog/2022-success-metrological.html" class="cta btn large">Read Success Story</a></p></div>
 </div>
 
 </section>


### PR DESCRIPTION
We've had an open problem for some time that we'd like to highlight more in the main page, and the suggestion was to add a carousel with success stories or use cases.  For whatever reason we currently have 2 issues: First, we only have 2 approved entries. Carousels are already usually not a great choice for a bunch of reasons, but a carousel with only 2 things in it just seems weird, to be honest.  The other issue is that carousels should really contain "like" things and these are not - one is a use case and the other is a success story. So, there's been a PR for some time at #168 but it isn't deploying and also makes a specific choice there.

I just wanted to offer a very very simple alternative: Let's literally just put two things in that section until we get at least a third?

----

Site preview: https://igalia.github.io/wpewebkit.org/carousel/