### PR TITLE
Use current Cog platform plug-in names in supported HW table

### DIFF
--- a/about/supported-hardware.md
+++ b/about/supported-hardware.md
@@ -115,62 +115,62 @@ Note that this list is not exhaustive. Reports of unlisted configurations are we
 
 ## NXP
 
-| Series  | GPU            | Driver      | WPE Backend | Cog Shells |
-|---------|----------------|-------------|-------------|------------|
-| i&period;MX 51 | Imageon Z460   | freedreno (reverse-engineered) | fdo | fdo, drm |
-| i&period;MX 53 | Imageon Z460   | freedreno (reverse-engineered) | fdo | fdo, drm |
-| i&period;MX 6  | Vivante GC880  | Vivante (Proprietary) | fdo | fdo, drm |
-| i&period;MX 6  | Vivante GC2000 | etnaviv (reverse-engineered) | fdo | fdo, drm |
-| i&period;MX 6  | Vivante GC2000 | Vivante (Proprietary) | fdo | fdo |
+| Series  | GPU            | Driver      | WPE Backend | Cog Platforms |
+|---------|----------------|-------------|-------------|---------------|
+| i&period;MX 51 | Imageon Z460   | freedreno (reverse-engineered) | fdo | wl, drm |
+| i&period;MX 53 | Imageon Z460   | freedreno (reverse-engineered) | fdo | wl, drm |
+| i&period;MX 6  | Vivante GC880  | Vivante (Proprietary) | fdo | wl, drm |
+| i&period;MX 6  | Vivante GC2000 | etnaviv (reverse-engineered) | fdo | wl, drm |
+| i&period;MX 6  | Vivante GC2000 | Vivante (Proprietary) | fdo | wl |
 | i&period;MX 6  | Vivante GC2000 | Vivante (Proprietary) | rdk, `VIV_IMX6_EGL` | n/a |
-| i&period;MX 8M | Vivante GC7000 | etnaviv (reverse-engineered) | fdo | fdo, drm |
-| i&period;MX 8M | Vivante GC7000 | Vivante (Proprietary) | fdo | fdo |
+| i&period;MX 8M | Vivante GC7000 | etnaviv (reverse-engineered) | fdo | wl, drm |
+| i&period;MX 8M | Vivante GC7000 | Vivante (Proprietary) | fdo | wl |
 
 ## Broadcom
 
-| Device         | GPU | Driver | WPE Backend | Cog Shells |
-|----------------|-----|--------|-------------|------------|
+| Device         | GPU | Driver | WPE Backend | Cog Platforms |
+|----------------|-----|--------|-------------|---------------|
 | Arris VIP5202W | VideoCore IV | Proprietary | rdk, `BCM_NEXUS` or `USE_BACKEND_BCM_NEXUS_WAYLAND` | n/a |
 | Raspberry Pi 3 | VideoCore IV | Proprietary | rdk, `BCM_RPI` | n/a |
-| Raspberry Pi 3 | VideoCore IV | Mesa vc4    | fdo | fdo, drm |
-| Raspberry Pi 4 | VideoCore V  | Mesa v3d    | fdo | fdo |
+| Raspberry Pi 3 | VideoCore IV | Mesa vc4    | fdo | wl, drm, headless |
+| Raspberry Pi 4 | VideoCore V  | Mesa v3d    | fdo | wl |
 
 
 ## Qualcomm
 
-| Device  | GPU | Driver | WPE Backend | Cog Shells |
-|---------|-----|--------|-------------|------------|
+| Device  | GPU | Driver | WPE Backend | Cog Platforms |
+|---------|-----|--------|-------------|---------------|
 | APQ8017 | Adreno 306 | Proprietary | Custom  | n/a |
 
 
 ## Nvidia
 
-| Device | GPU | Driver | WPE Backend | Cog Shells |
-|--------|-----|--------|-------------|------------|
+| Device | GPU | Driver | WPE Backend | Cog Platforms |
+|--------|-----|--------|-------------|---------------|
 | Jetson TK1 | Tegra K1 | | |
 
 
 ## RockChip
 
-| Device | GPU          | Driver | WPE Backend | Cog Shells |
-|--------|--------------|--------|-------------|------------|
-| RK3399 | Mali T860MP4 | panfrost (reverse-engineered) | fdo | fdo |
+| Device | GPU          | Driver | WPE Backend | Cog Platforms |
+|--------|--------------|--------|-------------|---------------|
+| RK3399 | Mali T860MP4 | panfrost (reverse-engineered) | fdo | wl |
 | RK3399 | Mali T860MP4 | Mali (Proprietary) | | |
 
 
 ## PC-style Hardware
 
-| Device | GPU | Driver | WPE Backend | Cog Shells |
-|--------|-----|--------|-------------|------------|
-| Any | AMD | Mesa amdgpu | fdo | fdo |
-| Any | Intel | Mesa i965 | fdo | fdo, drm   |
-| Any | Intel | Mesa iris | fdo | fdo, drm   |
+| Device | GPU | Driver | WPE Backend | Cog Platforms          |
+|--------|-----|--------|-------------|------------------------|
+| Any | AMD | Mesa amdgpu | fdo | wl, x11, gtk4, headless      |
+| Any | Intel | Mesa i965 | fdo | wl, x11, gtk4, headless, drm |
+| Any | Intel | Mesa iris | fdo | wl, x11, gtk4, headless, drm |
 
 
 ## Other
 
-| Device | GPU | Driver | WPE Backend | Cog Shells |
-|--------|-----|--------|-------------|------------|
+| Device | GPU | Driver | WPE Backend | Cog Platforms |
+|--------|-----|--------|-------------|---------------|
 | Beaglebone | PowerVR SGX530 | Proprietary | | |
 
 </section>

--- a/about/supported-hardware.md
+++ b/about/supported-hardware.md
@@ -56,20 +56,6 @@ table {
 	border-bottom: 2px solid black;
 	margin: 0;
 }
-@media (min-width: 45rem) {
-	table thead tr :nth-child(1) {
-		width: 18ch;
-	}
-	table thead tr :nth-child(2) {
-		width: 21ch;
-	}
-	table thead tr :nth-child(4) {
-		width: 35ch;
-	}
-	table thead tr :nth-child(5) {
-		width: 13ch;
-	}
-}
 table :is(thead, tbody) tr > * {
 	padding-left: 0;
 	vertical-align: top;


### PR DESCRIPTION
It has been a while since Cog has renamed “shells” to “platform plug-ins” and the “fdo” one to “wl”, so carry on the change to the hardware compatibility page.

While at it, avoid the column width sizing CSS rules, which caused the last columns to be too narrow for their contents.

----

Site preview: https://igalia.github.io/wpewebkit.org/hw-update-cog-shells/