### PR TITLE
Include /release/verify into HTML site map

### DIFF
--- a/release/verify/index.md
+++ b/release/verify/index.md
@@ -2,6 +2,7 @@
 title: Verifying Releases
 layout: post
 data: { dateless: "true" }
+skipHtmlSitemap: false
 sitemapChangeFrequency: yearly
 sitemapPriority: 0.4
 ---


### PR DESCRIPTION
The page at `/release/verify` was being skipped because it inherited the `skipHtmlSitemap` attribute from `release/release.json`. Override it in the page source to bring it back into the HTML site map page.

----

Site preview: https://igalia.github.io/wpewebkit.org/aperezdc/relverify-htmlsitemap/