### PR TITLE
Add link to documentation directory in each release page

### DIFF
--- a/_data/site.json
+++ b/_data/site.json
@@ -1,4 +1,5 @@
 {
-	"release_dir": "https://wpewebkit.org/releases/",
+	"release_dir": "https://wpewebkit.org/releases",
+	"api_ref_dir": "https://wpewebkit.org/reference",
 	"base_url": "https://wpewebkit.org"
 }

--- a/_includes/post.html
+++ b/_includes/post.html
@@ -29,9 +29,12 @@ header.page .btn-xl {
    <time itemprop="dateCreated">{{ page.date | date: "%e %B %Y" }}</time>
  {% endif %}
   {% if download %}
-  <a class="btn btn-xl btn-secondary mt-3" href="{{ download }}">Download</a>
+  <a class="btn btn-l btn-secondary mt-3" href="{{ download }}">Download</a>
   {% elsif package and version %}
-  <a class="btn btn-xl btn-secondary mt-3" href="{{ site.release_dir | append:'/' | append: package | append: '-' | append: version | append: '.tar.xz' }}">Download</a>
+  <a class="btn btn-l btn-secondary mt-3" href="{{ site.release_dir | append:'/' | append: package | append: '-' | append: version | append: '.tar.xz' }}">Download</a>
+    {%- if hasDocumentation and not hideDocumentation %}
+	<a class="btn btn-l btn-secondary mt-3" href="{{ site.api_ref_dir }}/{{ version }}/">Documentation</a>
+	{%- endif %}
   {% endif %}
 </header>
 

--- a/_includes/post.html
+++ b/_includes/post.html
@@ -29,11 +29,11 @@ header.page .btn-xl {
    <time itemprop="dateCreated">{{ page.date | date: "%e %B %Y" }}</time>
  {% endif %}
   {% if download %}
-  <a class="btn btn-l btn-secondary mt-3" href="{{ download }}">Download</a>
+  <a class="btn btn-l btn-primary mt-3" href="{{ download }}">Download</a>
   {% elsif package and version %}
-  <a class="btn btn-l btn-secondary mt-3" href="{{ site.release_dir | append:'/' | append: package | append: '-' | append: version | append: '.tar.xz' }}">Download</a>
+  <a class="btn btn-l btn-primary mt-3" href="{{ site.release_dir | append:'/' | append: package | append: '-' | append: version | append: '.tar.xz' }}">Download</a>
     {%- if hasDocumentation and not hideDocumentation %}
-	<a class="btn btn-l btn-secondary mt-3" href="{{ site.api_ref_dir }}/{{ version }}/">Documentation</a>
+	<a class="btn btn-l btn-primary mt-3" href="{{ site.api_ref_dir }}/{{ version }}/">Documentation</a>
 	{%- endif %}
   {% endif %}
 </header>

--- a/css/v2.css
+++ b/css/v2.css
@@ -159,6 +159,10 @@ nav.sitemap > ul {
 	margin: 0.5em 1.5em;
 }
 
+.btn-l {
+  border-radius: 4px;
+  padding: 0.5rem 1rem;
+}
 
 .cta.btn {
 	display: inline-block;
@@ -469,6 +473,10 @@ header.page h1 {
 }
 header.page p {
 	font-size: 1.6em;
+}
+header.page > time {
+	margin: 1rem 0;
+	display: block;
 }
 
 pre, code {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "markdown-it-anchor": "^9.0.0",
-        "markdown-it-toc-done-right": "^4.2.0"
+        "markdown-it-toc-done-right": "^4.2.0",
+        "semver": "^7.6.2"
       },
       "devDependencies": {
         "@11ty/eleventy": "^2.0.0",
@@ -2724,7 +2725,6 @@
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
       "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "markdown-it-anchor": "^9.0.0",
-    "markdown-it-toc-done-right": "^4.2.0"
+    "markdown-it-toc-done-right": "^4.2.0",
+    "semver": "^7.6.2"
   }
 }

--- a/release/release.11tydata.js
+++ b/release/release.11tydata.js
@@ -1,0 +1,12 @@
+const semverGreaterOrEqual = require("semver/functions/gte");
+module.exports = {
+	eleventyComputed: {
+		hasDocumentation: (data) => {
+			if (!Object.hasOwn(data, "package") || !Object.hasOwn(data, "version"))
+				return false;
+			if (data.package !== "wpewebkit")
+				return false;
+			return semverGreaterOrEqual(data.version, '2.23.90');
+		},
+	},
+};

--- a/release/release.json
+++ b/release/release.json
@@ -1,5 +1,6 @@
 {
 	"layout": "post",
 	"tags": ["release"],
-	"skipHtmlSitemap": true
+	"skipHtmlSitemap": true,
+	"hideDocumentation": false
 }


### PR DESCRIPTION
Add a button to the documentation directory under `/reference` for those releases that have it. A small JS data script adds a `hasDocumentation` computed data property to each page, which will be true in release pages for the `wpewebkit` package, from versions `2.23.90` onwards (inclusive). The version comparison is done reusing the `semver` package. Just in case there might be some release after that version that does not have documentation, the `hideDocumentation` data attribute is also honored.

While at it, fix the post date being close tight to the download and documentation buttons. Instead, promote the `<time>` element containing the date to a block, which causes it to occupy its own “line”. To avoid stealing much vertical space for the buttons, a new `.btn-l` CSS class is added, similar to `.btn-xl`, which produces smaller buttons.

----

Site preview: https://igalia.github.io/wpewebkit.org/aperezdc/release-doc-links/