### PR TITLE
developers: Link to the general documentation location

### DIFF
--- a/developers/index.md
+++ b/developers/index.md
@@ -44,6 +44,8 @@ API documentation for the **latest stable release** is available here:
 <li><a href="https://wpewebkit.org/reference/stable/wpe-web-extension-1.1/">WPEWebExtension 1.1 API documentation</a> (deprecated)</li>
 </ul>
 
+Documentation is also available for a number of [other releases](/reference).
+
 </div>
 
 <div class="dotsep">


### PR DESCRIPTION
Add a link to `/reference`, which contains the API documentation for releases that have it available, one subdirectory per version.

----

Site preview: https://igalia.github.io/wpewebkit.org/aperezdc/developers-doc-link/