### PR TITLE
Update FAQ about WebRTC

### DIFF
--- a/about/faq.md
+++ b/about/faq.md
@@ -50,13 +50,13 @@ The WebKit project provides a [features status page](https://webkit.org/status/)
 The WPE project currently does not have an official list of the Web features it supports. It might provide one in the future, but for the time being, we recommend users check for specific features by testing WPE through the Cog browser.
 
 
-## What's the status regarding WebRTC? 
+## What's the status regarding WebRTC?
 
 As of March 2022 the facts are:
 
 1. [WPEWebKit upstream has support for WebRTC](https://blogs.gnome.org/tsaunier/2018/07/31/webkitgtk-and-wpe-gains-webrtc-support-back/), by relying on [LibWebRTC](https://webrtc.googlesource.com/src/).
 2. LibWebRTC is bundled as third-party library in WebKit's upstream repository.
-3. The LibWebRTC backend doesn't support hardware-accelerated encoders and decoders.
+3. The LibWebRTC backend supports hardware-acceleration only for decoding. Encoding is supported only via software encoders.
 4. LibWebRTC bundles [BoringSSL](https://boringssl.googlesource.com/boringssl/), which is a fork of OpenSSL started while OpenSSL
    was still under the dual OpenSSL and SSLeay licences.
 
@@ -67,7 +67,7 @@ Taking these facts into account, the WPEWebKit maintainers have decided to leave
 - The lack of hardware-accelerated support in LibWebRTC would incur a bad
   performance impact on the embedded platforms that WPE targets.
 
-In order to solve these issues, an alternative WebRTC backend based on [GstWebRTC](http://blog.nirbheek.in/2018/02/gstreamer-webrtc.html) will be enabled by default in the WPE upstream CMake build, hopefully during 2023; bug [#235885](https://bugs.webkit.org/show_bug.cgi?id=235885) is being used to track progress. This new backend will seamlessly integrate with hardware-accelerated encoders and decoders on most embedded platforms. GstWebRTC depends on [OpenSSL](https://www.openssl.org/), which is released under an Apache-style license, so it doesn't have limitations regarding redistribution in binary form.
+In order to solve these issues, an alternative WebRTC backend based on [GstWebRTC](http://blog.nirbheek.in/2018/02/gstreamer-webrtc.html) will be enabled by default in the WPE upstream CMake build, hopefully soon; bug [#235885](https://bugs.webkit.org/show_bug.cgi?id=235885) is being used to track progress. This new backend will seamlessly integrate with hardware-accelerated encoders and decoders on most embedded platforms. GstWebRTC depends on [OpenSSL](https://www.openssl.org/), which is released under an Apache-style license, so it doesn't have limitations regarding redistribution in binary form.
 
 
 ## What's up with EME? How can I support this feature in my WPE-based product?


### PR DESCRIPTION
1. The libwebrtc backend now supports hardware-accelerated decoding, but not encoding.
2. Update outdated ETA for enabling GstWebRTC upstream by default.

----

Site preview: https://igalia.github.io/wpewebkit.org/update-webrtc-faq/