### PR TITLE
Add a new RSS feed for security advisories

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -100,6 +100,13 @@ module.exports = function(eleventyConfig) {
     });
   })
 
+  eleventyConfig.addCollection("recentWSAs", (collectionApi) => {
+    let i = 0;
+    return collectionApi.getFilteredByTag("WSA").reverse().filter((item) => {
+      return i++ < 6;
+    });
+  })
+
   eleventyConfig.addCollection("pkgCatalog", collection => {
     let pkgCatalog = new Object;
     collection.getAll().forEach(item => {

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -30,8 +30,9 @@
   <meta name="description" content="{{ page_description | escape }}">
   {%- endif %}
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | htmlBaseUrl: site.base_url }}">
-  <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ '/feed.xml' | htmlBaseUrl: site.base_url  }}">
-  <link rel="alternate" type="application/rss+xml" title="WPE blog" href="{{ '/blog.xml' | htmlBaseUrl: site.base_url  }}">
+  <link rel="alternate" type="application/rss+xml" title="WPE WebKit Blog" href="{{ '/blog.xml' | htmlBaseUrl: site.base_url  }}">
+  <link rel="alternate" type="application/rss+xml" title="WPE WebKit Posts" href="{{ '/feed.xml' | htmlBaseUrl: site.base_url  }}">
+  <link rel="alternate" type="application/rss+xml" title="WPE WebKit Security Advisories" href="{{ '/security.xml' | htmlBaseUrl: site.base_url }}">
 
   {%- comment %}
   <!-- OpenGraph metadata, see https://ogp.me -->

--- a/security.njk
+++ b/security.njk
@@ -1,0 +1,31 @@
+---json
+{
+  "eleventyExcludeFromCollections": true,
+  "permalink": "/security.xml",
+  "metadata": {
+    "title": "WPE WebKit Security Advisories",
+    "description": "WebKit Security Advisories from wpewebkit.org",
+    "url": "https://wpewebkit.org/security/",
+    "feedUrl": "https://wpewebkit.org/security.xml"
+  }
+}
+---
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>{{ metadata.title }}</title>
+  <description>{{ metadata.description }}</description>
+  <link href="{{ metadata.feedUrl }}" rel="self"/>
+  <link href="{{ metadata.url }}"/>
+  <updated>{{ collections.recentWSAs | getNewestCollectionItemDate | dateToRfc3339 }}</updated>
+  <id>{{ metadata.url }}</id>
+  {%- for post in collections.recentPosts %}
+  {% set absolutePostUrl %}{{ post.url | url | absoluteUrl(metadata.url) }}{% endset %}
+  <entry>
+    <title>{{ post.data.title }}</title>
+    <link href="{{ absolutePostUrl }}"/>
+    <updated>{{ post.date | dateToRfc3339 }}</updated>
+    <id>{{ absolutePostUrl }}</id>
+    <content type="html">{{ post.templateContent | htmlToAbsoluteUrls(absolutePostUrl) }}</content>
+  </entry>
+  {%- endfor %}
+</feed>


### PR DESCRIPTION
While at it, improve the titles of the feed links from the page head.

Fixes #185

----

Site preview: https://igalia.github.io/wpewebkit.org/wsa-security-feed/