### PR TITLE
developers: Remove link to FAQ

### DIFF
--- a/developers/index.md
+++ b/developers/index.md
@@ -81,8 +81,3 @@ WPE WebKit and [WebKitGTK](https://webkitgtk.org/) share a fair amount of code. 
 </div>
 <img src="/assets/img/diagram-WPE-design.svg" alt="">
 </div>
-
-<div class="dotsep">
-<h2><a href="/about/faq.html">WPE’s Frequently Asked Questions</a></h2>
-<p>We've been collecting answers to lots of common questions we've been asked. If you've got questions, you might just find a ready answer in the FAQ.</p>
-</div>


### PR DESCRIPTION
It is already in discover/

Fixes #196