### PR TITLE
Remove duplicate "Developers" section in front page

### DIFF
--- a/index.html
+++ b/index.html
@@ -483,28 +483,6 @@ Open standards with great longevity allows lots more things to benefit from the 
   </div>
 </section>
 
-<section class="developers embedded dotsep">
-<div>
-
-<header class="full-bleed">
-<h2><a href="/developers">Developers</a></h2>
-<img src="/assets/img/illustration-resources.svg" alt="" class="decoration">
-</header>
-
-<div class="c2 dotsep">
-<h3><a href="/about/architecture.html">WPE Design</a></h3>
-<p>WPE is the official WebKit port for embedded platforms. WPE is uniquely designed for embedded systems in that it doesn’t depend on any user-interface toolkits such as the traditional Cocoa, GTK, etc toolkits.</p>
-<img src="/assets/img/diagram-WPE-design.svg" alt="" class="decoration">
-</div>
-
-<div class="c2 dotsep text">
-<h3><a href="/about/faq.html">WPE’s Frequently Asked Questions</a></h3>
-<p>We’ve been collecting answers to lots of common questions we’ve been asked. If you have questions, you might find a ready answer in the FAQ.</p>
-</div>
-
-</div>
-</section>
-
 <section class="igalia full-width">
 <div>
 


### PR DESCRIPTION
Fixes #249

----

Site preview: https://igalia.github.io/wpewebkit.org/aperezdc/remove-dupe-developers-section/