### PR TITLE
Disable the drop-shadow effect for header.page div > *

### DIFF
--- a/index.html
+++ b/index.html
@@ -182,9 +182,13 @@ header.page div::before {
 	width: 1px;
 	background: var(--dashV);
 }
-header.page div > * {
-	filter: drop-shadow(0 0 1px #0008) drop-shadow(0 0 2px #0008) drop-shadow(0 0 4px #0008) drop-shadow(0 0 8px #0008);
-}
+/* Temporarily disable this drop-shadow, it breaks on Chromium-based
+ * browsers on Linux in some cases when GPU acceleration is enabled
+ *
+ * header.page div > * { filter: drop-shadow(0 0 1px #0008) drop-shadow(0 0 2px
+ *     #0008) drop-shadow(0 0 4px #0008) drop-shadow(0 0 8px #0008);
+ * }
+ */
 header.page div h1 {
 	font-size: 3em;
 	font-weight: 400;


### PR DESCRIPTION
Temporarily disable this drop-shadow, it breaks on Chromium-based browsers on Linux in some cases when GPU acceleration is enabled, causing artifacts like this:

![image](https://github.com/user-attachments/assets/1b32dcdb-cf3d-42dc-a402-dfad58b7f43e)

Canary builds of Chromium seem to work better now, but there are still some artifacts when text is being selected, so let's remove this for now.


----

Site preview: https://igalia.github.io/wpewebkit.org/dropshadow/