### PR TITLE
blog: Fix pagination permalink expression

### DIFF
--- a/blog.md
+++ b/blog.md
@@ -10,7 +10,7 @@ pagination:
   data: collections.blogpost
   reverse: true
   size: 7
-permalink: /blog/{% if pagination.pageNumber > 0 %}{{ (pagination.pageNumber + 1) }}/{% endif %}
+permalink: "/blog/{% if pagination.pageNumber > 0 %}{{ pagination.pageNumber | plus: 1 }}/{% endif %}"
 ---
 <style>
 .card ol {


### PR DESCRIPTION
Using mathematical operations inside `{{ expression }}` does not work in all versions of the Liquid template engine, specially with newer versions as the templating engine attempts to improve compatibility with the original implementation. Instead of `+ 1`, use the `plus:` filter to adjust the page number of blog pagination permalinks, and quote the value in the front matter to avoid the YAML parser choking up on the colon.

----

Site preview: https://igalia.github.io/wpewebkit.org/aperezdc/fix-pagination-permalink/