### PR TITLE
Fix checkout in Github Action for PRs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,6 +11,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Setup Node
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
The current action is checking out the code from master instead of checking out the code from the PR that is the one that should be tested and deployed on the test URL.

See example of wrongdoing: https://github.com/Igalia/wpewebkit.org/actions/runs/15057304460/job/42325774952 (from PR #259)

```
Run actions/checkout@v3
Syncing repository: Igalia/wpewebkit.org
Getting Git version info
Temporarily overriding HOME='/home/runner/work/_temp/cc75343e-bb47-4a97-b36c-1646add25a2a' before making global git config changes
Adding repository directory to the temporary git global config as a safe directory
/usr/bin/git config --global --add safe.directory /home/runner/work/wpewebkit.org/wpewebkit.org
Deleting the contents of '/home/runner/work/wpewebkit.org/wpewebkit.org'
Initializing the repository
Disabling automatic garbage collection
Setting up auth
Fetching the repository
Determining the checkout info
Checking out the ref
/usr/bin/git log -1 --format='%H'
'5c1ecd97a563fa7c3705e6a7c236063270313053'
```
And 5c1ecd97a563fa7c3705e6a7c236063270313053 is current master, not the HEAD from the PR that has to be tested


----

Site preview: https://igalia.github.io/wpewebkit.org/pr_fix_checkout_github_action/