### PR TITLE
Remove NVIDIA Jetson TK1 from the list of supported HW

### DIFF
--- a/about/supported-hardware.md
+++ b/about/supported-hardware.md
@@ -129,13 +129,6 @@ Note that this list is not exhaustive. Reports of unlisted configurations are we
 | APQ8017 | Adreno 306 | Proprietary | Custom  | n/a |
 
 
-## Nvidia
-
-| Device | GPU | Driver | WPE Backend | Cog Platforms |
-|--------|-----|--------|-------------|---------------|
-| Jetson TK1 | Tegra K1 | | |
-
-
 ## RockChip
 
 | Device | GPU          | Driver | WPE Backend | Cog Platforms |


### PR DESCRIPTION
We haven't recently tested this SoC and it's unclear which version of WPE would be supported there, despite of the SoC being quite capable, so we better remove it from the website to avoid confusion.

----

Site preview: https://igalia.github.io/wpewebkit.org/remove-tegra-k1/