### PR TITLE
Fix broken link to 'WPE in Action' anchor

### DIFF
--- a/about/supported-hardware.md
+++ b/about/supported-hardware.md
@@ -82,7 +82,7 @@ table tbody tr:nth-child(n + 2) > * {
 <ul>
 <li class="currentPage"><a href="/about/supported-hardware.html">Supported Hardware</a></li>
 <li><a href="/about/a-good-choice.html">Why Choose WPE?</a></li>
-<li><a href="#wpe-in-action">WPE in Action</a></li>
+<li><a href="/about/#wpe-in-action">WPE in Action</a></li>
 </ul>
 </nav>
 


### PR DESCRIPTION
It's missing the /about prefix.

----

Site preview: https://igalia.github.io/wpewebkit.org/anchor-fix/